### PR TITLE
ARXIVNG-262 added support for wildcards and literals

### DIFF
--- a/search/controllers/advanced/forms.py
+++ b/search/controllers/advanced/forms.py
@@ -6,11 +6,13 @@ from wtforms import Form, BooleanField, StringField, SelectField, validators, \
 from wtforms.fields import HiddenField
 from wtforms import widgets
 
+from search.controllers.util import doesNotStartWithWildcard
+
 
 class FieldForm(Form):
     """Subform for query parts on specific fields."""
 
-    term = StringField("Search term...")
+    term = StringField("Search term...", validators=[doesNotStartWithWildcard])
     operator = SelectField("Operator", choices=[
         ('AND', 'AND'), ('OR', 'OR'), ('NOT', 'NOT')
     ], default='AND')
@@ -93,7 +95,7 @@ class AdvancedSearchForm(Form):
     advanced = HiddenField('Advanced', default=1)
     """Used to indicate whether the form should be shown."""
 
-    terms = FieldList(FormField(FieldForm), min_entries=0)
+    terms = FieldList(FormField(FieldForm), min_entries=1)
     classification = FormField(ClassificationForm)
     date = FormField(DateForm)
     size = SelectField('results per page', default=25, choices=[

--- a/search/controllers/advanced/forms.py
+++ b/search/controllers/advanced/forms.py
@@ -26,7 +26,6 @@ class FieldForm(Form):
 class ClassificationForm(Form):
     """Subform for selecting a classification to (disjunctively) filter by."""
 
-    all_subjects = BooleanField('All subjects')
     computer_science = BooleanField('Computer science (cs)')
     economics = BooleanField('Economics (econ)')
     eess = BooleanField('Electrical Engineering and Systems Science (eess)')

--- a/search/controllers/authors/forms.py
+++ b/search/controllers/authors/forms.py
@@ -6,11 +6,15 @@ from wtforms import Form, BooleanField, StringField, SelectField, validators, \
 from wtforms.fields import HiddenField
 from wtforms import widgets
 
+from search.controllers.util import doesNotStartWithWildcard
+
 
 class AuthorForm(Form):
     forename = StringField("Forename", validators=[validators.Length(min=1),
-                                                   validators.Optional()])
-    surname = StringField("Surname", validators=[validators.Length(min=1)])
+                                                   validators.Optional(),
+                                                   doesNotStartWithWildcard])
+    surname = StringField("Surname", validators=[validators.Length(min=1),
+                                                 doesNotStartWithWildcard])
 
 
 class AuthorSearchForm(Form):

--- a/search/controllers/simple/__init__.py
+++ b/search/controllers/simple/__init__.py
@@ -73,6 +73,7 @@ def search(request_params: dict) -> Response:
 
     # Fall back to form-based search.
     form = SimpleSearchForm(request_params)
+    q = None
     if form.validate():
         logger.debug('form is valid')
         q = _query_from_form(form)
@@ -96,7 +97,7 @@ def search(request_params: dict) -> Response:
     else:
         logger.debug('form is invalid: %s' % str(form.errors))
         q = None
-        response_data['query'] = q
+    response_data['query'] = q
     response_data['form'] = form
     return response_data, status.HTTP_200_OK, {}
 

--- a/search/controllers/simple/forms.py
+++ b/search/controllers/simple/forms.py
@@ -19,8 +19,7 @@ class SimpleSearchForm(Form):
         ('abstract', 'Abstract')
     ])
     query = StringField('Search or Article ID',
-                        validators=[validators.Length(min=1),
-                                    doesNotStartWithWildcard])
+                        validators=[doesNotStartWithWildcard])
     size = SelectField('results per page', default=25, choices=[
         ('25', '25'),
         ('50', '50'),
@@ -31,3 +30,13 @@ class SimpleSearchForm(Form):
         ('submitted_date', 'Submission date (ascending)'),
         ('-submitted_date', 'Submission date (descending)'),
     ], validators=[validators.Optional()])
+
+    def validate_query(form: Form, field: StringField) -> None:
+        """Validate the length of the querystring, if searchtype is set."""
+        print(form.searchtype.data)
+        if form.searchtype.data is None or form.searchtype.data == 'None':
+            return
+        if not form.query.data or len(form.query.data) < 1:
+            raise validators.ValidationError(
+                'Field must be at least 1 character long.'
+            )

--- a/search/controllers/simple/forms.py
+++ b/search/controllers/simple/forms.py
@@ -6,8 +6,12 @@ from wtforms import Form, BooleanField, StringField, SelectField, validators, \
 from wtforms.fields import HiddenField
 from wtforms import widgets
 
+from search.controllers.util import doesNotStartWithWildcard
+
 
 class SimpleSearchForm(Form):
+    """Provides a simple field-query search form."""
+
     searchtype = SelectField("Field", choices=[
         ('all', 'All fields'),
         ('title', 'Title'),
@@ -15,7 +19,8 @@ class SimpleSearchForm(Form):
         ('abstract', 'Abstract')
     ])
     query = StringField('Search or Article ID',
-                        validators=[validators.Length(min=1)])
+                        validators=[validators.Length(min=1),
+                                    doesNotStartWithWildcard])
     size = SelectField('results per page', default=25, choices=[
         ('25', '25'),
         ('50', '50'),

--- a/search/controllers/util.py
+++ b/search/controllers/util.py
@@ -1,0 +1,11 @@
+"""Controller helpers."""
+
+from wtforms import Form, StringField, validators
+
+
+def doesNotStartWithWildcard(form: Form, field: StringField) -> None:
+    """Check that ``value`` does not start with a wildcard character."""
+    if not field.data:
+        return
+    if field.data.startswith('?') or field.data.startswith('*'):
+        raise validators.ValidationError('Search cannot start with a wildcard')

--- a/search/services/index.py
+++ b/search/services/index.py
@@ -1,7 +1,9 @@
 """Integration with search index."""
 
 import json
+import re
 from math import floor
+from typing import Tuple
 from functools import wraps
 from elasticsearch import Elasticsearch, ElasticsearchException, \
                           SerializationError, TransportError
@@ -33,6 +35,51 @@ class QueryError(ValueError):
 
 class DocumentNotFound(RuntimeError):
     """Could not find a requested document in the search index."""
+
+
+# We'll compile this ahead of time, since it gets called quite a lot.
+STRING_LITERAL = re.compile(r"(['\"][^'\"]*['\"])")
+
+
+def _wildcardEscape(querystring: str) -> Tuple[str, bool]:
+    """
+    Detect wildcard characters, and escape any that occur within a literal.
+
+    Parameters
+    ----------
+    querystring : str
+
+    Returns
+    -------
+    str
+        Query string with wildcard characters enclosed in literals escaped.
+    bool
+        If a non-literal wildcard character is present, returns True.
+    """
+    # This should get caught by the controller (form validation), but just
+    # in case we should check for it here.
+    if querystring.startswith('?') or querystring.startswith('*'):
+        raise QueryError('Query cannot start with a wildcard')
+
+    # Escape wildcard characters within string literals.
+    # re.sub() can't handle the complexity, sadly...
+    parts = re.split(STRING_LITERAL, querystring)
+    parts = [part.replace('*', '\*').replace('?', '\?')
+             if part.startswith('"') or part.startswith("'") else part
+             for part in parts]
+    querystring = "".join(parts)
+
+    # Only unescaped wildcard characters should remain.
+    wildcard = re.search(r'(?<!\\)([\*\?])', querystring) is not None
+    return querystring, wildcard
+
+
+def _Q(qtype: str, field: str, value: str) -> Q:
+    """Construct a :class:`.Q`, but handle wildcards first."""
+    value, wildcard = _wildcardEscape(value)
+    if wildcard:
+        return Q('wildcard', **{field: value})
+    return Q(qtype, **{field: value})
 
 
 class SearchSession(object):
@@ -93,15 +140,15 @@ class SearchSession(object):
     def _field_term_to_q(term) -> Q:
         if term.field in ['title', 'abstract']:
             return (
-                Q("match", **{f'{term.field}__tex': term.term})
-                | Q("match", **{f'{term.field}__english': term.term})
+                _Q("match", f'{term.field}__tex', term.term)
+                | _Q("match", f'{term.field}__english', term.term)
             )
         elif term.field == 'author':
             return Q('nested', path='authors', query=(
-                Q('match', **{'authors__first_name__folded': term.term}) |
-                Q('match', **{'authors__last_name__folded': term.term})
+                _Q('match', 'authors__first_name__folded', term.term) |
+                _Q('match', 'authors__last_name__folded', term.term)
             ))
-        return Q("match", **{term.field: term.term})
+        return _Q("match", term.field, term.term)
 
     @staticmethod
     def _grouped_terms_to_q(term_pair: tuple) -> Bool:
@@ -135,8 +182,18 @@ class SearchSession(object):
                 .strftime('%Y-%m-%dT%H:%M:%S%z')
         return Q('range', submitted_date=params)
 
+    @classmethod
+    def _fielded_terms_to_q(cls, query: Query) -> Match:
+        if len(query.terms) == 1:
+            return SearchSession._field_term_to_q(query.terms[0])
+            # return Q("match", **{query.terms[0].field: query.terms[0].term})
+        elif len(query.terms) > 1:
+            terms = cls._group_terms(query)
+            return cls._grouped_terms_to_q(terms)
+        return Q('match_all')
+
     @staticmethod
-    def _class_to_q(field: str, classification: Classification) \
+    def _classification_to_q(field: str, classification: Classification) \
             -> Match:
         q = Q()
         if classification.group:
@@ -151,24 +208,15 @@ class SearchSession(object):
         return Q('nested', path=field, query=q)
 
     @classmethod
-    def _fielded_terms_to_q(cls, query: Query) -> Match:
-        if len(query.terms) == 1:
-            return SearchSession._field_term_to_q(query.terms[0])
-            # return Q("match", **{query.terms[0].field: query.terms[0].term})
-        elif len(query.terms) > 1:
-            terms = cls._group_terms(query)
-            return cls._grouped_terms_to_q(terms)
-        return Q('match_all')
-
-    @classmethod
     def _classifications_to_q(cls, query: Query) -> Match:
         if not query.primary_classification:
             return Q()
-        q = cls._class_to_q('primary_classification',
-                            query.primary_classification[0])
+        q = cls._classification_to_q('primary_classification',
+                                     query.primary_classification[0])
         if len(query.primary_classification) > 1:
             for classification in query.primary_classification[1:]:
-                q |= cls._class_to_q('primary_classification', classification)
+                q |= cls._classification_to_q('primary_classification',
+                                              classification)
         return q
 
     @classmethod
@@ -200,32 +248,32 @@ class SearchSession(object):
         if query.field == 'all':
             search = search.query(
                 Q('nested', path='authors', query=(
-                    Q('match', **{'authors__first_name__folded': query.value})
+                    _Q('match', 'authors__first_name__folded', query.value)
                     |
-                    Q('match', **{'authors__last_name__folded': query.value})
+                    _Q('match', 'authors__last_name__folded', query.value)
                 ))
                 |
-                Q('match', **{'title__english': query.value})
+                _Q('match', 'title__english', query.value)
                 |
-                Q('match', **{'title__tex': query.value})
+                _Q('match', 'title__tex', query.value)
                 |
-                Q('match', **{'abstract__english': query.value})
+                _Q('match', 'abstract__english', query.value)
                 |
-                Q('match', **{'abstract__tex': query.value})
+                _Q('match', 'abstract__tex', query.value)
             )
         elif query.field == 'author':
             search = search.query(
                 Q('nested', path='authors', query=(
-                    Q('match', **{'authors__first_name__folded': query.value})
+                    _Q('match', 'authors__first_name__folded', query.value)
                     |
-                    Q('match', **{'authors__last_name__folded': query.value})
+                    _Q('match', 'authors__last_name__folded', query.value)
                 ))
             )
         else:
             search = search.query(
-                Q('match', **{f'{query.field}__english': query.value})
+                _Q('match', f'{query.field}__english', query.value)
                 |
-                Q('match', **{f'{query.field}__tex': query.value})
+                _Q('match', f'{query.field}__tex', query.value)
             )
         search = self._apply_sort(query, search)
         return search
@@ -234,14 +282,14 @@ class SearchSession(object):
         search = Search(using=self.es, index=self.index)
         q = Q()
         for au in query.authors:
-            _q = Q('match', **{'authors__last_name__folded': au.surname})
+            _q = _Q('match', 'authors__last_name__folded', au.surname)
 
             if au.forename:    # Try as both forename and initials.
                 _q_init = Q()
                 for i in au.forename.replace('.', ' ').split():
-                    _q_init &= Q('match', **{'authors__initials__folded': i})
+                    _q_init &= _Q('match', 'authors__initials__folded', i)
                 _q &= (
-                    Q('match', **{'authors__first_name__folded': au.forename})
+                    _Q('match', 'authors__first_name__folded', au.forename)
                     |
                     _q_init
                 )

--- a/search/templates/search/advanced_search.html
+++ b/search/templates/search/advanced_search.html
@@ -27,7 +27,6 @@
     {% if form.errors %}
     <div class="notification is-warning">
       Whoops! Something went wrong. Please correct errors in the form below.
-      {{ form.errors }}
     </div>
     {% endif %}
     <div class="box">
@@ -37,11 +36,6 @@
         {# Field-specific search term fieldset. #}
         <section data-toggle="fieldset" id="terms-fieldset">
           {% for entry in form.terms.entries %}
-            {% if entry.errors %}
-              <div class="notification is-warning">
-                {{ entry.errors }}
-              </div>
-            {% endif %}
             <div class="field has-addons" data-toggle="fieldset-entry">
               <div class="control fieldset-hidden-on-first-row" {% if loop.index0 == 0 %}style="visibility:hidden;"{% endif %}>
                 <span class="select" aria-label="Boolean operator">
@@ -50,7 +44,19 @@
               </div>
               <div class="control is-expanded">
                 <label for="terms-{{loop.index0}}-term" class="hidden-label">Search term</label>
-                {{ entry.term(class='input', placeholder="Search term...")|safe }}
+                {% if entry.term.errors %}
+                  {{ entry.term(class='input is-warning', placeholder="Search term...")|safe }}
+                {% else %}
+                  {{ entry.term(class='input', placeholder="Search term...")|safe }}
+                {% endif %}
+                {% if entry.term.errors %}
+                  <div class="help is-warning">
+                    {% for error in entry.term.errors %}
+                        {{ error }}
+                    {% endfor %}
+                  </div>
+                {% endif %}
+
               </div>
               <div class="control">
                 <label for="terms-{{loop.index0}}-field" class="hidden-label">Field to search</label>

--- a/search/templates/search/advanced_search.html
+++ b/search/templates/search/advanced_search.html
@@ -100,14 +100,7 @@
                 {% endfor %}
               {% endfor %}
             {% endif %}
-            <div class="field">
-              {% if form.classification.all_subjects.errors %}
-                {{ form.classification.all_subjects(class="is-danger")|safe }}
-              {% else %}
-                {{ form.classification.all_subjects|safe }}
-              {% endif %}
-              {{ form.classification.all_subjects.label }}
-            </div>
+            <div class="help has-text-grey">All classifications will be included by default.</div>
             <div class="columns is-baseline">
               <div class="column">
                 {{ select_field(form.classification.computer_science) }}

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -3,10 +3,8 @@
 {% import "search/search-macros.html" as search_macros %}
 
 {% block title %}
-    {% if query and results %}
+    {% if results %}
         Showing {{ metadata.total }} results for {{ query.field }}: {{ query.value }}
-    {% elif query and not results %}
-        Sorry, your query for <span class="is-warning">{{ query.field }}: {{ query.value }}</span> produced no results
     {% else %}
         Search
     {% endif %}
@@ -58,9 +56,14 @@
   </div>
 </form>
 
+{% if query and not results %}
+  <div class="is-size-4 has-text-warning">
+    Sorry, your query for <span class="is-warning">{{ query.field }}: {{ query.value }}</span> produced no results.
+  </div>
+{% endif %}
+
 {% if results %}
     {{ search_macros.search_results(form, results, metadata, external_url, url_for_page) }}
-
 {% endif %}
 
 {% endblock %}

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -17,7 +17,18 @@
 <form method="GET" action="{{ url_for('ui.search') }}">
   <div class="field has-addons">
     <div class="control is-expanded">
-      {{ form.query(class="input is-medium")|safe }}
+      {% if form.query.errors %}
+        {{ form.query(class="input is-medium is-warning")|safe }}
+      {% else %}
+        {{ form.query(class="input is-medium")|safe }}
+      {% endif %}
+      {% if form.query.errors %}
+        <div class="help is-warning">
+          {% for error in form.query.errors %}
+              {{ error }}
+          {% endfor %}
+        </div>
+      {% endif %}
     </div>
     <div class="select control is-medium">
       {{ form.searchtype(class="is-medium")|safe }}

--- a/tests/test_controller_advanced.py
+++ b/tests/test_controller_advanced.py
@@ -141,6 +141,16 @@ class TestAdvancedSearchForm(TestCase):
         form = AdvancedSearchForm(data)
         self.assertTrue(form.validate())
 
+    def test_term_starts_with_wildcard(self):
+        """User has entered a string that starts with a wildcard."""
+        data = MultiDict({
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'title',
+            'terms-0-term': '*foo'
+        })
+        form = AdvancedSearchForm(data)
+        self.assertFalse(form.validate(), "Form should be invalid")
+
     def test_only_one_date_selection_allowed(self):
         """If the user selects more than one date option, form is invalid."""
         data = MultiDict({

--- a/tests/test_controller_advanced.py
+++ b/tests/test_controller_advanced.py
@@ -154,6 +154,9 @@ class TestAdvancedSearchForm(TestCase):
     def test_only_one_date_selection_allowed(self):
         """If the user selects more than one date option, form is invalid."""
         data = MultiDict({
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'title',
+            'terms-0-term': 'foo',
             'date-past_12': True,
             'date-specific_year': True,
             'date-year': '2012'
@@ -165,6 +168,9 @@ class TestAdvancedSearchForm(TestCase):
     def test_specific_year_must_be_specified(self):
         """If the user selects specific year, they must indicate a year."""
         data = MultiDict({
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'title',
+            'terms-0-term': 'foo',
             'date-specific_year': True,
         })
         form = AdvancedSearchForm(data)
@@ -172,6 +178,9 @@ class TestAdvancedSearchForm(TestCase):
         self.assertEqual(len(form.errors), 1)
 
         data = MultiDict({
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'title',
+            'terms-0-term': 'foo',
             'date-specific_year': True,
             'date-year': '2012'
         })
@@ -181,6 +190,9 @@ class TestAdvancedSearchForm(TestCase):
     def test_date_range_must_be_specified(self):
         """If the user selects date range, they must indicate start or end."""
         data = MultiDict({
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'title',
+            'terms-0-term': 'foo',
             'date-date_range': True,
         })
         form = AdvancedSearchForm(data)
@@ -188,6 +200,9 @@ class TestAdvancedSearchForm(TestCase):
         self.assertEqual(len(form.errors), 1)
 
         data = MultiDict({
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'title',
+            'terms-0-term': 'foo',
             'date-date_range': True,
             'date-from_date': '2012-02-05'
         })
@@ -195,6 +210,9 @@ class TestAdvancedSearchForm(TestCase):
         self.assertTrue(form.validate())
 
         data = MultiDict({
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'title',
+            'terms-0-term': 'foo',
             'date-date_range': True,
             'date-to_date': '2012-02-05'
         })
@@ -204,6 +222,9 @@ class TestAdvancedSearchForm(TestCase):
     def test_year_must_be_after_1990(self):
         """If the user selects a specific year, it must be after 1990."""
         data = MultiDict({
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'title',
+            'terms-0-term': 'foo',
             'date-specific_year': True,
             'date-year': '1990'
         })
@@ -211,6 +232,9 @@ class TestAdvancedSearchForm(TestCase):
         self.assertFalse(form.validate())
 
         data = MultiDict({
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'title',
+            'terms-0-term': 'foo',
             'date-specific_year': True,
             'date-year': '1991'
         })

--- a/tests/test_controller_authors.py
+++ b/tests/test_controller_authors.py
@@ -156,6 +156,15 @@ class TestAuthorSearchForm(TestCase):
         form = AuthorSearchForm(data)
         self.assertTrue(form.validate(), "Form should be valid")
 
+    def test_value_starts_with_wildcard(self):
+        """User has entered a value that starts with wildcard."""
+        data = MultiDict({
+            'authors-0-forename': '*david',
+            'authors-0-surname': 'davis'
+        })
+        form = AuthorSearchForm(data)
+        self.assertFalse(form.validate(), "Form should be invalid")
+
 
 class TestRewriteSimpleParams(TestCase):
     """Tests for :func:`.authors._rewrite_simple_params`."""

--- a/tests/test_controller_simple.py
+++ b/tests/test_controller_simple.py
@@ -278,3 +278,12 @@ class TestQueryFromForm(TestCase):
         self.assertIsInstance(query, SimpleQuery,
                               "Should return an instance of SimpleQuery")
         self.assertIsNone(query.order, "Order should be None")
+
+    def test_querystring_has_wildcard_at_start(self):
+        """Querystring starts with a wildcard."""
+        data = MultiDict({
+            'searchtype': 'title',
+            'query': '*foo title'
+        })
+        form = SimpleSearchForm(data)
+        self.assertFalse(form.validate(), "Form should be invalid")

--- a/tests/test_services_index.py
+++ b/tests/test_services_index.py
@@ -11,6 +11,102 @@ from search.domain import Query, FieldedSearchTerm, DateRange, Classification,\
 EASTERN = timezone('US/Eastern')
 
 
+class TestWildcardSearch(TestCase):
+    """A wildcard [*?] character is present in a querystring."""
+
+    def test_match_any_wildcard_is_present(self):
+        """A * wildcard is present in the query."""
+        qs = "Foo t*"
+        qs_escaped, wildcard = index._wildcardEscape(qs)
+
+        self.assertTrue(wildcard, "Wildcard should be detected")
+        self.assertEqual(qs, qs_escaped, "The querystring should be unchanged")
+        self.assertEqual(
+            index._Q('match', 'title', qs),
+            index.Q('wildcard', title=qs),
+            "Wildcard Q object should be generated"
+        )
+
+    def test_match_any_wildcard_in_literal(self):
+        """A * wildcard is present in a string literal."""
+        qs = '"Foo t*"'
+        qs_escaped, wildcard = index._wildcardEscape(qs)
+
+        self.assertEqual(qs_escaped, '"Foo t\*"', "Wildcard should be escaped")
+        self.assertFalse(wildcard, "Wildcard should not be detected")
+        self.assertEqual(
+            index._Q('match', 'title', qs),
+            index.Q('match', title='"Foo t\*"'),
+            "Wildcard Q object should not be generated"
+        )
+
+    def test_multiple_match_any_wildcard_in_literal(self):
+        """Multiple * wildcards are present in a string literal."""
+        qs = '"Fo*o t*"'
+        qs_escaped, wildcard = index._wildcardEscape(qs)
+
+        self.assertEqual(qs_escaped, '"Fo\*o t\*"',
+                         "Both wildcards should be escaped")
+        self.assertFalse(wildcard, "Wildcard should not be detected")
+        self.assertEqual(
+            index._Q('match', 'title', qs),
+            index.Q('match', title='"Fo\*o t\*"'),
+            "Wildcard Q object should not be generated"
+        )
+
+    def test_mixed_wildcards_in_literal(self):
+        """Both * and ? characters are present in a string literal."""
+        qs = '"Fo? t*"'
+        qs_escaped, wildcard = index._wildcardEscape(qs)
+
+        self.assertEqual(qs_escaped, '"Fo\? t\*"',
+                         "Both wildcards should be escaped")
+        self.assertFalse(wildcard, "Wildcard should not be detected")
+        self.assertEqual(
+            index._Q('match', 'title', qs),
+            index.Q('match', title='"Fo\? t\*"'),
+            "Wildcard Q object should not be generated"
+        )
+
+    def test_wildcards_both_inside_and_outside_literal(self):
+        """Wildcard characters are present both inside and outside literal."""
+        qs = '"Fo? t*" said the *'
+        qs_escaped, wildcard = index._wildcardEscape(qs)
+
+        self.assertEqual(qs_escaped, '"Fo\? t\*" said the *',
+                         "Wildcards in literal should be escaped")
+        self.assertTrue(wildcard, "Wildcard should be detected")
+        self.assertEqual(
+            index._Q('match', 'title', qs),
+            index.Q('wildcard', title='"Fo\? t\*" said the *'),
+            "Wildcard Q object should be generated"
+        )
+
+    def test_wildcards_inside_outside_multiple_literals(self):
+        """Wildcard chars are everywhere, and there are multiple literals."""
+        qs = '"Fo?" s* "yes*" o?'
+        qs_escaped, wildcard = index._wildcardEscape(qs)
+
+        self.assertEqual(qs_escaped, '"Fo\?" s* "yes\*" o?',
+                         "Wildcards in literal should be escaped")
+        self.assertTrue(wildcard, "Wildcard should be detected")
+
+        self.assertEqual(
+            index._Q('match', 'title', qs),
+            index.Q('wildcard', title='"Fo\?" s* "yes\*" o?'),
+            "Wildcard Q object should be generated"
+        )
+
+    def test_wildcard_at_opening_of_string(self):
+        """A wildcard character is the first character in the querystring."""
+        with self.assertRaises(index.QueryError):
+            index._wildcardEscape("*nope")
+
+        with self.assertRaises(index.QueryError):
+            index._Q('match', 'title', '*nope')
+
+
+
 class TestPrepare(TestCase):
     """
     Tests for :meth:`.index.SearchSession._prepare`.


### PR DESCRIPTION
Wildcards should now be working in simple, author, and advanced search. 

Basically what I did was...

- Introduce a function in ``search.services.index`` called ``_wildcardEscape`` that escapes any wildcards in string literals, and then checks to see if there are any remaining wildcard characters that should be treated as such.
- Introduce a wrapper for elasticsearch_dsl.Q that returns a "wildcard" query part if the querystring has a wildcard in it, and otherwise falls back to whatever query type was specified.

Made a couple of other minor opportunistic improvements.
