### PR TITLE
ARXIVNG-279 Implemented indexing agent for populating test index

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ elasticsearch-dsl==6.1.0
 wtforms==2.1
 arxiv-base>=0.1
 pytz==2017.3
+amazon-kclpy==1.4.4

--- a/search/agent/__init__.py
+++ b/search/agent/__init__.py
@@ -1,0 +1,13 @@
+"""
+The search agent is responsible for updating the index as papers are published.
+
+The agent consumes notifications on the ``MetadataIsAvailable`` stream. For
+each notification, the agent retrieves metadata for the most recent version of
+the indicated paper from the :mod:`search.services.metadata` service. The agent
+also retrieves metadata for earlier versions, if there are multiple versions
+available. Each version is passed to the :mod:`search.services.index` service,
+and becomes available for discovery via the :mod:`search.routes.ui` and
+:mod:`search.routes.external_api`.
+"""
+
+from .consumer import MetadataRecordProcessor

--- a/search/agent/__init__.py
+++ b/search/agent/__init__.py
@@ -10,4 +10,4 @@ and becomes available for discovery via the :mod:`search.routes.ui` and
 :mod:`search.routes.external_api`.
 """
 
-from .consumer import MetadataRecordProcessor
+from .consumer import MetadataRecordProcessor, DocumentFailed, IndexingFailed

--- a/search/agent/base.py
+++ b/search/agent/base.py
@@ -1,0 +1,181 @@
+"""
+Provides a base class for Kinesis record handling.
+
+TODO: This should move to arXiv-base, per ARXIVNG-281.
+
+http://docs.aws.amazon.com/streams/latest/dev/kinesis-record-processor-implementation-app-py.html
+https://github.com/awslabs/amazon-kinesis-client-python/blob/master/samples/sample_kclpy_app.py
+"""
+
+import time
+import logging
+import json
+import os
+import amazon_kclpy
+from amazon_kclpy import kcl
+from amazon_kclpy.v2 import processor
+from amazon_kclpy.messages import ProcessRecordsInput, ShutdownInput
+
+logger = logging.getLogger(__name__)
+
+
+class BaseRecordProcessor(processor.RecordProcessorBase):
+    """
+    Processes records received by the Kinesis consumer.
+
+    This class is instantiated when the containing script is run by the
+    MultiLangDaemon. The underlying KCL process handles threading, offset
+    tracking, etc. The KCL guarantees that our :class:`.RecordProcessor` will
+    see each record *at least* once; the checkpoint mechanism gives us a way to
+    further guarantee that we only process each record a single time.
+
+    See the ``consumer.properties`` file for configuration details, including
+    streams.
+    """
+
+    def __init__(self):
+        """Initialize checkpointing state and retry configuration."""
+        self._SLEEP_SECONDS = 5
+        self._CHECKPOINT_RETRIES = 5
+        self._CHECKPOINT_FREQ = 60
+        self._largest_seq = (None, None)
+        self._largest_sub_seq = None
+        self._last_checkpoint_time = None
+
+    def initialize(self, initialize_input):
+        """Called once by a KCLProcess before any calls to process_records."""
+        self._largest_seq = (None, None)
+        self._last_checkpoint_time = time.time()
+
+    def checkpoint(self, checkpointer: amazon_kclpy.kcl.Checkpointer,
+                   sequence_number=None,
+                   sub_sequence_number=None) -> None:
+        """Make periodic checkpoints while processing records."""
+        for n in range(0, self._CHECKPOINT_RETRIES):
+            try:
+                checkpointer.checkpoint(sequence_number, sub_sequence_number)
+                return
+            except kcl.CheckpointError as e:
+                if 'ShutdownException' == e.value:
+                    # A ShutdownException indicates that this record processor
+                    #  should be shutdown. This is due to some failover event,
+                    #  e.g. another MultiLangDaemon has taken the lease for
+                    #  this shard.
+                    logger.info("Encountered shutdown exception, skipping"
+                                " checkpoint")
+                    return
+                elif 'ThrottlingException' == e.value:
+                    # A ThrottlingException indicates that one of our
+                    #  dependencies is is over burdened, e.g. too many dynamo
+                    #  writes. We will sleep temporarily to let it recover.
+                    if self._CHECKPOINT_RETRIES - 1 == n:
+                        logger.error("Failed to checkpoint after %i attempts,"
+                                     " giving up." % n)
+                        return
+                    else:
+                        logger.info("Was throttled while checkpointing, will"
+                                    " attempt again in %i seconds"
+                                    % self._SLEEP_SECONDS)
+                elif 'InvalidStateException' == e.value:
+                    logger.error("MultiLangDaemon reported an invalid state"
+                                 " while checkpointing.")
+                else:  # Some other error
+                    logger.error("Encountered an error while checkpointing,"
+                                 " error was %s" % e)
+            time.sleep(self._SLEEP_SECONDS)
+
+    def should_update_sequence(self, sequence_number: int,
+                               sub_sequence_number: int) -> bool:
+        """
+        Determine whether a new larger sequence number is available.
+
+        Parameters
+        ----------
+        sequence_number : int
+        sub_sequence_number : int
+
+        Returns
+        -------
+        bool
+        """
+        return (self._largest_seq == (None, None) or
+                sequence_number > self._largest_seq[0] or
+                (sequence_number == self._largest_seq[0] and
+                 sub_sequence_number > self._largest_seq[1]))
+
+    def shutdown(self, shutdown: ShutdownInput) -> None:
+        """
+        Shut down record processing gracefully, if possible.
+
+        Called by a KCLProcess instance to indicate that this record processor
+        should shutdown. After this is called, there will be no more calls to
+        any other methods of this record processor.
+
+        Parameters
+        ----------
+        shutdown : :class:`amazon_kclpy.messages.ShutdownInput`
+        """
+        try:
+            if shutdown.reason == 'TERMINATE':
+                # **THE RECORD PROCESSOR MUST CHECKPOINT OR THE KCL WILL BE
+                #   UNABLE TO PROGRESS**
+                # Checkpointing with no parameter will checkpoint at the
+                # largest sequence number reached by this processor on this
+                # shard id.
+                logger.info("Was told to terminate, attempting to checkpoint.")
+                self.checkpoint(shutdown.checkpointer, None)
+            else:    # reason == 'ZOMBIE'
+                # **ATTEMPTING TO CHECKPOINT ONCE A LEASE IS LOST WILL FAIL**
+                logger.info("Shutting down due to failover. Won't checkpoint.")
+        except Exception as e:
+            logger.error("Encountered exception while shutting down: %s" % e)
+
+    def process_records(self, records: ProcessRecordsInput) -> None:
+        """
+        Handle a series of records from the stream.
+
+        Called by a KCLProcess with a list of records to be processed and a
+        checkpointer which accepts sequence numbers from the records to
+        indicate where in the bytestream to checkpoint.
+
+        Parameters
+        ----------
+        records : :class:`amazon_kclpy.messages.ProcessRecordsInput`
+        """
+        try:
+            for record in records.records:
+                data = record.binary_data
+                seq = int(record.sequence_number)
+                sub_seq = record.sub_sequence_number
+                key = record.partition_key
+                self.process_record(data, key, seq, sub_seq)
+                if self.should_update_sequence(seq, sub_seq):
+                    self._largest_seq = (seq, sub_seq)
+
+            # Checkpoints every self._CHECKPOINT_FREQ seconds
+            last_check = time.time() - self._last_checkpoint_time
+            if last_check > self._CHECKPOINT_FREQ:
+                self.checkpoint(records.checkpointer,
+                                str(self._largest_seq[0]),
+                                self._largest_seq[1])
+                self._last_checkpoint_time = time.time()
+
+        except Exception as e:
+            logger.error("Encountered an exception while processing records."
+                         " Exception was %s" % e)
+            logger.error("Seq: %i; Sub seq: %i; Key: %s" % (seq, sub_seq, key))
+            logger.error("{}".format(data))
+
+    def process_record(self, data: bytes, partition_key: bytes,
+                       sequence_number: int, sub_sequence_number: int) -> None:
+        """
+        Hook for method to be executed for each record.
+
+        Parameters
+        ----------
+        data : bytes
+        partition_key : bytes
+        sequence_number : int
+        sub_sequence_number : int
+        """
+        raise NotImplementedError('Must be implemented by child class')

--- a/search/agent/consumer.py
+++ b/search/agent/consumer.py
@@ -1,0 +1,226 @@
+"""Provides a record processor for MetadataIsAvailable notifications."""
+
+import json
+import time
+from search import logging
+from search.services import metadata, index
+from search.process import transform
+from search.domain import DocMeta, Document
+from .base import BaseRecordProcessor, ProcessRecordsInput
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentFailed(RuntimeError):
+    """Raised when an arXiv paper could not be added to the search index."""
+
+
+class IndexingFailed(RuntimeError):
+    """Raised when indexing failed such that future success is unlikely."""
+
+
+class MetadataRecordProcessor(BaseRecordProcessor):
+    """Consumes ``MetadataIsAvailable`` notifications, updates the index."""
+
+    MAX_ERRORS = 5
+    """Max number of individual document failures before aborting entirely."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize exception counter."""
+        super(MetadataRecordProcessor, self).__init__(*args, **kwargs)
+        self._error_count = 0
+
+    def _get_metadata(self, arxiv_id: str) -> DocMeta:
+        """
+        Retrieve metadata from the :mod:`.metadata` service.
+
+        Parameters
+        ----------
+        arxiv_id : str
+            Am arXiv identifier, with or without a version affix.
+
+        Returns
+        -------
+        :class:`.DocMeta`
+            Metadata for the arXiv paper.
+
+        Raises
+        ------
+        DocumentFailed
+            Indexing of the document failed. This may have no bearing on the
+            success of subsequent papers.
+        IndexingFailed
+            Indexing of the document failed in a way that indicates recovery
+            is unlikely for subsequent papers.
+        """
+        try:
+            logger.debug(f'{arxiv_id}: requesting metadata')
+            docmeta = metadata.retrieve(arxiv_id)
+        except metadata.ConnectionFailed as e:
+            # The metadata service will retry bad responses, but not connection
+            # errors. Sometimes it just takes another try, so why not.
+            logger.warning(f'{arxiv_id}: first attempt failed, retrying')
+            try:
+                docmeta = metadata.retrieve(arxiv_id)
+            except metadata.ConnectionFailed as e:
+                # Things really are looking bad. There is no need to keep
+                # trying with subsequent records, so let's abort entirely.
+                logger.error(f'{arxiv_id}: second attempt failed, giving up')
+                raise IndexingFailed(
+                    'Indexing failed; metadata endpoint could not be reached.'
+                ) from e
+        except metadata.RequestFailed as e:
+            logger.error(f'{arxiv_id}: request failed')
+            raise DocumentFailed('Request to metadata service failed') from e
+        except metadata.BadResponse as e:
+            logger.error(f'{arxiv_id}: bad response from metadata service')
+            raise DocumentFailed('Bad response from metadata service') from e
+        except Exception as e:
+            logger.error(f'{arxiv_id}: unhandled error from metadata service')
+            raise IndexingFailed('Unhandled exception') from e
+        return docmeta
+
+    def _transform_to_document(docmeta: DocMeta) -> Document:
+        """
+        Transform paper :class:`.DocMeta` to a search :class:`.Document`.
+
+        Parameters
+        ----------
+        docmeta : :class:`DocMeta`
+            Metadata for an arXiv paper.
+
+        Returns
+        -------
+        :class:`.Document`
+            A search document ready for indexing.
+
+        Raises
+        ------
+        DocumentFailed
+            Indexing of the document failed. This may have no bearing on the
+            success of subsequent papers.
+        """
+        try:
+            document = transform.to_search_document(docmeta)
+        except Exception as e:
+            # At the moment we don't have any special exceptions.
+            logger.error(f'{arxiv_id}: unhandled exception during transform')
+            raise DocumentFailed('Could not transform document') from e
+        return document
+
+    def _add_to_index(self, document: Document) -> None:
+        """
+        Add a :class:`.Document` to the search index.
+
+        Parameters
+        ----------
+        document : :class:`.Document`
+
+        Raises
+        ------
+        DocumentFailed
+            Indexing of the document failed. This may have no bearing on the
+            success of subsequent papers.
+        IndexingFailed
+            Indexing of the document failed in a way that indicates recovery
+            is unlikely for subsequent papers.
+        """
+        try:
+            index.add_document(document)
+        except index.IndexConnectionError as e:
+            # Let's try once more before giving up entirely.
+            try:
+                index.add_document(document)
+            except index.IndexConnectionError as e:   # Nope, not happening.
+                raise IndexingFailed('Could not index document') from e
+        except Exception as e:
+            logger.error(f'{arxiv_id}: unhandled exception from index service')
+            raise IndexingFailed('Unhandled exception') from e
+
+    # TODO: update this based on the final verdict on submission/announcement
+    #  dates.
+    def index_paper(self, arxiv_id: str) -> None:
+        """
+        Index a paper, including its previous versions.
+
+        Parameters
+        ----------
+        arxiv_id : str
+            A **versionless** arXiv e-print identifier.
+
+        Raises
+        ------
+        DocumentFailed
+            Indexing of the document failed. This may have no bearing on the
+            success of subsequent papers.
+        IndexingFailed
+            Indexing of the document failed in a way that indicates recovery
+            is unlikely for subsequent papers.
+        """
+        try:
+            docmeta = self._get_metadata(arxiv_id)
+            document = self._transform_to_search_document(docmeta)
+
+            current_version = docmeta.get('version', None)
+            if current_version is not None and current_version > 1:
+                for version in range(1, current_version):
+                    ver_docmeta = self._get_metadata(f'{arxiv_id}v{version}')
+                    ver_document = self._transform_to_document(ver_docmeta)
+
+                    # The earlier versions are here primarily to respond to
+                    # queries that explicitly specify the version number.
+                    ver_document['is_latest'] = False
+
+                    # Attach submission dates from earlier versions so that
+                    # they respond to queries for earlier time periods.
+                    document['submission_dates'].append(
+                        ver_docmeta['submission_date']
+                    )
+                    # Add a reference to the most recent version.
+                    ver_document['latest'] = f'{arxiv_id}v{current_version}'
+
+            # Finally, index the most recent version.
+            document['is_latest'] = True
+            self._add_to_index(document)
+        except (DocumentFailed, IndexingFailed) as e:
+            # We just pass these along so that process_record() can keep track.
+            raise
+
+    # TODO: verify notification payload on MetadataIsAvailable stream.
+    def process_record(self, data: bytes, partition_key: bytes,
+                       sequence_number: int, sub_sequence_number: int) -> None:
+        """
+        Called for each record that is passed to process_records.
+
+        Parameters
+        ----------
+        data : bytes
+        partition_key : bytes
+        sequence_number : int
+        sub_sequence_number : int
+
+        Raises
+        ------
+        IndexingFailed
+            Indexing of the document failed in a way that indicates recovery
+            is unlikely for subsequent papers, or too many individual
+            documents failed.
+        """
+        if self._error_count > self.MAX_ERRORS:
+            raise IndexingFailed('Too many errors')
+
+        try:
+            deserialized = json.loads(data.decode('utf-8'))
+        except Exception as e:
+            logger.error("Error while deserializing data: %s" % e)
+            logger.error("Data payload: %s" % data)
+            return   # Don't bring down the whole batch.
+
+        try:
+            arxiv_id: str = deserialized.get('document_id')
+            self.index_paper(arxiv_id)
+        except DocumentFailed as e:
+            logger.debug(f'{arxiv_id}: failed to index document')
+            self._error_count += 1
+        except IndexingFailed as e:
+            raise

--- a/search/controllers/simple/forms.py
+++ b/search/controllers/simple/forms.py
@@ -33,7 +33,6 @@ class SimpleSearchForm(Form):
 
     def validate_query(form: Form, field: StringField) -> None:
         """Validate the length of the querystring, if searchtype is set."""
-        print(form.searchtype.data)
         if form.searchtype.data is None or form.searchtype.data == 'None':
             return
         if not form.query.data or len(form.query.data) < 1:

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -84,7 +84,7 @@ class SchemaBase(Base):
         if key in self or not hasattr(self, key):
             self[key] = value
             return
-        setattr(SchemaBase, self).__setattr__(key, value)
+        super(SchemaBase, self).__setattr__(key, value)
 
     @property
     def valid(self):

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -72,6 +72,20 @@ class SchemaBase(Base):
 
     __schema__ = None
 
+    def __getattr__(self, key: str) -> Any:
+        try:
+            super(SchemaBase, self).__getattr__(key)
+        except AttributeError:
+            if key in self:
+                return self[key]
+        raise AttributeError('No such attribute')
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key in self or not hasattr(self, key):
+            self[key] = value
+            return
+        setattr(SchemaBase, self).__setattr__(key, value)
+
     @property
     def valid(self):
         """Indicate whether the domain object is valid, per its __schema__."""

--- a/search/process/transform.py
+++ b/search/process/transform.py
@@ -5,6 +5,7 @@ from typing import Optional
 from search.domain import Document, DocMeta, Fulltext
 
 
+# QUESTION: is this still necessary? Input and output formats look the same.
 def _reformatDate(datestring: str,
                   output_format: str = '%Y-%m-%dT%H:%M:%S%z') -> str:
     """Recast DocMeta date format to ES date format."""
@@ -19,14 +20,15 @@ def _prepareSubmitter(meta: DocMeta) -> dict:
     return meta['submitter']
 
 
+# QUESTION: is it not true that we are no longer expecting information about
+# previous versions in the docmeta response?
 def _constructSubDate(meta: DocMeta) -> list:
-    previous_versions = meta.get('previous_versions', [])
-    current = _reformatDate(meta['created'])
-    previous = [_reformatDate(v['created']) for v in previous_versions]
-    # TODO: comparison should probably be done on datetime objects, not strings
-    # now that dates are no longer YYMMDD
-    previous = list(filter(lambda o: o is not None, previous))
-    return list(sorted([current] + previous))[::-1]
+    # previous_versions = meta.get('previous_versions', [])
+    # current = _reformatDate(meta['created'])
+    # previous = [_reformatDate(v['created']) for v in previous_versions]
+    # previous = list(filter(lambda o: o is not None, previous))
+    # return list(sorted([current] + previous))[::-1]
+    return [_reformatDate(meta['created'])]
 
 
 def _constructPaperVersion(meta: DocMeta) -> str:
@@ -63,14 +65,12 @@ def _constructAuthors(meta: DocMeta) -> dict:
 
 
 _transformations = [
+    ('id', 'paper_id'),
     ('abstract', 'abstract'),
     ('authors', _constructAuthors),
     ('authors_freeform', "authors_utf8"),
     ("author_owners", "author_owners"),
-
     ("submitted_date", _constructSubDate),
-    ("submitted_date_first", lambda meta: _constructSubDate(meta)[-1]),
-    ("submitted_date_latest", lambda meta: _reformatDate(meta['created'])),
     ("modified_date", lambda meta: _reformatDate(meta['modtime'])),
     ("updated_date", lambda meta: _reformatDate(meta['updated'])),
     ("is_current", "is_current"),
@@ -90,7 +90,6 @@ _transformations = [
     ("metadata_id", "metadata_id"),
     ("journal_ref", "journal_ref_utf8"),
     ("is_withdrawn", "is_withdrawn"),
-    ("is_current", "is_current"),
     ("doi", "doi"),
     ("comments", "comments_utf8"),
     ("acm_class", _constructACMClass),

--- a/search/services/index.py
+++ b/search/services/index.py
@@ -335,8 +335,9 @@ class SearchSession(object):
             Problem serializing ``document`` for indexing.
         """
         try:
+            ident = document.get('id', document['paper_id'])
             self.es.index(index=self.index, doc_type='document',
-                          id=document['paper_id'], body=document)
+                          id=ident, body=document)
         except SerializationError as e:
             raise IndexingError('Problem serializing document: %s' % e) from e
         except TransportError as e:

--- a/search/services/index.py
+++ b/search/services/index.py
@@ -24,6 +24,10 @@ class IndexConnectionError(IOError):
     """There was a problem connecting to the search index."""
 
 
+class IndexingError(IOError):
+    """There was a problem adding a document to the index."""
+
+
 class QueryError(ValueError):
     """
     Elasticsearch could not handle the query.
@@ -334,7 +338,7 @@ class SearchSession(object):
             self.es.index(index=self.index, doc_type='document',
                           id=document['paper_id'], body=document)
         except SerializationError as e:
-            raise QueryError('Problem serializing document: %s' % e) from e
+            raise IndexingError('Problem serializing document: %s' % e) from e
         except TransportError as e:
             raise IndexConnectionError(
                 'Problem communicating with ES: %s' % e

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,31 @@
+"""Unit tests for :mod:`search.agent`."""
+
+from unittest import TestCase, mock
+
+from search.domain import DocMeta, Document
+from search.services import metadata, index
+from search.agent import consumer
+
+
+class TestGetMetadata(TestCase):
+    """Retrieve metadata for an arXiv e-print."""
+
+    def setUp(self):
+        """Initialize a :class:`.MetadataRecordProcessor`."""
+        self.processor = consumer.MetadataRecordProcessor()
+
+    @mock.patch('search.agent.consumer.metadata')
+    def test_metadata_service_returns_metadata(self, mock_metadata):
+        """The metadata service returns valid metadata."""
+        docmeta = DocMeta()
+        mock_metadata.retrieve.return_value = docmeta
+        self.assertEqual(docmeta, self.processor._get_metadata('1234.5678'),
+                         "The metadata is returned.")
+
+    @mock.patch('search.agent.consumer.metadata')
+    def test_metadata_service_raises_connection_error(self, mock_metadata):
+        """The metadata service returns valid metadata."""
+        mock_metadata.ConnectionFailed = metadata.ConnectionFailed
+        mock_metadata.retrieve.side_effect = metadata.ConnectionFailed
+        with self.assertRaises(consumer.IndexingFailed):
+            self.processor._get_metadata('1234.5678')

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,10 +1,143 @@
 """Unit tests for :mod:`search.agent`."""
 
 from unittest import TestCase, mock
-
+# from datetime import datetime
+# from pytz import timezone
 from search.domain import DocMeta, Document
 from search.services import metadata, index
 from search.agent import consumer
+
+# EASTERN = timezone('US/Eastern')
+
+
+class TestIndexPaper(TestCase):
+    """Re-index all versions of an arXiv paper."""
+
+    def setUp(self):
+        """Initialize a :class:`.MetadataRecordProcessor`."""
+        self.processor = consumer.MetadataRecordProcessor()
+
+    @mock.patch('search.agent.consumer.index')
+    @mock.patch('search.agent.consumer.transform')
+    @mock.patch('search.agent.consumer.metadata')
+    def test_paper_has_one_version(self, mock_meta, mock_tx, mock_idx):
+        """The arXiv paper has only one version."""
+        mock_docmeta = DocMeta(version=1, paper_id='1234.56789', title='foo',
+                               created='2001-03-02T03:04:05-400')
+        mock_meta.retrieve.return_value = mock_docmeta
+        mock_doc = Document(version=1, paper_id='1234.56789', title='foo',
+                            submitted_date=['2001-03-02T03:04:05-400'])
+        mock_tx.to_search_document.return_value = mock_doc
+
+        self.processor.index_paper('1234.56789')
+
+        self.assertEqual(mock_meta.retrieve.call_count, 1,
+                         "Only the metadata for the current version should be"
+                         " retrieved")
+        self.assertEqual(mock_idx.add_document.call_count, 1,
+                         "Only the current version should be indexed")
+
+        indexed = mock_idx.add_document.call_args[0][0]
+        self.assertTrue(indexed.is_current,
+                        "Should be flagged as the most recent version")
+        self.assertEqual(len(indexed.submitted_date), 1,
+                         "Only the submission date of the current version"
+                         " should be included")
+
+    @mock.patch('search.agent.consumer.index')
+    @mock.patch('search.agent.consumer.transform')
+    @mock.patch('search.agent.consumer.metadata')
+    def test_paper_has_three_versions(self, mock_meta, mock_tx, mock_idx):
+        """The arXiv paper has three versions."""
+        mock_dm_1 = DocMeta(version=1, paper_id='1234.56789', title='foo',
+                            created='2001-03-02T03:04:05-400')
+        mock_dm_2 = DocMeta(version=2, paper_id='1234.56789', title='foo',
+                            created='2001-03-03T03:04:05-400')
+        mock_dm_3 = DocMeta(version=3, paper_id='1234.56789', title='foo',
+                            created='2001-03-04T03:04:05-400')
+        mock_meta.retrieve.side_effect = [mock_dm_3, mock_dm_1, mock_dm_2]
+        mock_doc_1 = Document(version=1, paper_id='1234.56789', title='foo',
+                              submitted_date=['2001-03-02T03:04:05-400'])
+        mock_doc_2 = Document(version=2, paper_id='1234.56789', title='foo',
+                              submitted_date=['2001-03-03T03:04:05-400'])
+        mock_doc_3 = Document(version=3, paper_id='1234.56789', title='foo',
+                              submitted_date=['2001-03-04T03:04:05-400'])
+        mock_tx.to_search_document.side_effect = [
+            mock_doc_3, mock_doc_1, mock_doc_2
+        ]
+        self.processor.index_paper('1234.56789')
+        self.assertEqual(mock_meta.retrieve.call_count, 3,
+                         "Metadata should be retrieved for each version.")
+        self.assertEqual(mock_idx.add_document.call_count, 3,
+                         "All three versions should be indexed.")
+
+        last_indexed = mock_idx.add_document.call_args[0][0]
+        self.assertTrue(last_indexed.is_current,
+                        "Should be flagged as the most recent version")
+        self.assertEqual(len(last_indexed.submitted_date), 3,
+                         "Submission dates from all three versions should be"
+                         " included.")
+
+
+class TestAddToIndex(TestCase):
+    """Add a search document to the index."""
+
+    def setUp(self):
+        """Initialize a :class:`.MetadataRecordProcessor`."""
+        self.processor = consumer.MetadataRecordProcessor()
+
+    @mock.patch('search.agent.consumer.index')
+    def test_add_document_succeeds(self, mock_index):
+        """The search document is added successfully."""
+        try:
+            self.processor._add_to_index(Document())
+        except Exception as e:
+            self.fail(e)
+        self.assertEqual(mock_index.add_document.call_count, 1)
+
+    @mock.patch('search.agent.consumer.index')
+    def test_index_raises_index_connection_error(self, mock_index):
+        """The index raises :class:`.index.IndexConnectionError`."""
+        mock_index.IndexConnectionError = index.IndexConnectionError
+
+        mock_index.add_document.side_effect = index.IndexConnectionError
+        with self.assertRaises(consumer.IndexingFailed):
+            self.processor._add_to_index(Document())
+
+    @mock.patch('search.agent.consumer.index')
+    def test_index_raises_unhandled_error(self, mock_index):
+        """The index raises an unhandled exception."""
+        mock_index.IndexConnectionError = index.IndexConnectionError
+
+        mock_index.add_document.side_effect = RuntimeError
+        with self.assertRaises(consumer.IndexingFailed):
+            self.processor._add_to_index(Document())
+
+
+class TestTransformToDocument(TestCase):
+    """Transform metadata into a search document."""
+
+    def setUp(self):
+        """Initialize a :class:`.MetadataRecordProcessor`."""
+        self.processor = consumer.MetadataRecordProcessor()
+
+    @mock.patch('search.agent.consumer.transform')
+    def test_transform_returns_document(self, mock_transform):
+        """The transform module returns a :class:`.Document`."""
+        document = Document()
+        mock_transform.to_search_document.return_value = document
+        self.assertEqual(
+            self.processor._transform_to_document(DocMeta()),
+            document,
+            "The search document is returned."
+        )
+
+    @mock.patch('search.agent.consumer.transform')
+    def test_transform_raises_exception(self, mock_transform):
+        """The transform module raises an exception."""
+        mock_transform.to_search_document.side_effect = RuntimeError
+        with self.assertRaises(consumer.DocumentFailed):
+            self.processor._transform_to_document(DocMeta())
 
 
 class TestGetMetadata(TestCase):
@@ -24,8 +157,33 @@ class TestGetMetadata(TestCase):
 
     @mock.patch('search.agent.consumer.metadata')
     def test_metadata_service_raises_connection_error(self, mock_metadata):
-        """The metadata service returns valid metadata."""
+        """The metadata service raises :class:`.metadata.ConnectionFailed`."""
         mock_metadata.ConnectionFailed = metadata.ConnectionFailed
+        mock_metadata.RequestFailed = metadata.RequestFailed
+        mock_metadata.BadResponse = metadata.BadResponse
+
         mock_metadata.retrieve.side_effect = metadata.ConnectionFailed
         with self.assertRaises(consumer.IndexingFailed):
+            self.processor._get_metadata('1234.5678')
+
+    @mock.patch('search.agent.consumer.metadata')
+    def test_metadata_service_raises_request_error(self, mock_metadata):
+        """The metadata service raises :class:`.metadata.RequestFailed`."""
+        mock_metadata.ConnectionFailed = metadata.ConnectionFailed
+        mock_metadata.RequestFailed = metadata.RequestFailed
+        mock_metadata.BadResponse = metadata.BadResponse
+
+        mock_metadata.retrieve.side_effect = metadata.RequestFailed
+        with self.assertRaises(consumer.DocumentFailed):
+            self.processor._get_metadata('1234.5678')
+
+    @mock.patch('search.agent.consumer.metadata')
+    def test_metadata_service_raises_bad_response(self, mock_metadata):
+        """The metadata service raises :class:`.metadata.BadResponse`."""
+        mock_metadata.ConnectionFailed = metadata.ConnectionFailed
+        mock_metadata.RequestFailed = metadata.RequestFailed
+        mock_metadata.BadResponse = metadata.BadResponse
+
+        mock_metadata.retrieve.side_effect = metadata.BadResponse
+        with self.assertRaises(consumer.DocumentFailed):
             self.processor._get_metadata('1234.5678')


### PR DESCRIPTION
I refactored ``populate_test_metadata`` to use ``search.agent.consumer.MetadataRecordProcessor``, which now has everything except the Kinesis glue. This should be sufficient to populate the test index for beta deploy, once we've stabilized the search document.