### PR TITLE
ARXIVNG-308 user may optionally search by author full name (text match, not keyword)

### DIFF
--- a/mappings/DocumentMapping.json
+++ b/mappings/DocumentMapping.json
@@ -9,6 +9,14 @@
             "lowercase"
           ]
         },
+        "folding": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "icu_folding",
+            "lowercase"
+          ]
+        },
         "tex_analyzer": {
           "type": "custom",
           "tokenizer": "tex_tokenizer"
@@ -94,7 +102,8 @@
               }
             },
             "full_name": {
-              "type": "text"
+              "type": "text",
+              "analyzer": "folding"
             },
             "suffix": {
               "type": "keyword"

--- a/search/controllers/authors/__init__.py
+++ b/search/controllers/authors/__init__.py
@@ -105,7 +105,11 @@ def _query_from_form(form: AuthorSearchForm) -> AuthorQuery:
     :class:`.AuthorQuery`
     """
     q = AuthorQuery(authors=AuthorList([
-        Author(forename=author['forename'], surname=author['surname'])
+        Author(
+            forename=author['forename'],
+            surname=author['surname'],
+            fullname=author['fullname']
+        )
         for author in form.authors.data
     ]))
     order = form.order.data
@@ -131,4 +135,6 @@ def _rewrite_simple_params(params: dict) -> dict:
         params['authors-0-forename'] = params['forename']
     if 'surname' in params:
         params['authors-0-surname'] = params['surname']
+    if 'fullname' in params:
+        params['authors-0-fullname'] = params['fullname']
     return params

--- a/search/controllers/authors/forms.py
+++ b/search/controllers/authors/forms.py
@@ -11,16 +11,25 @@ from wtforms import widgets
 from search.controllers.util import doesNotStartWithWildcard
 
 
+def validate_fullname(form: Form, field: StringField) -> None:
+    """Either fullname or surname must be set."""
+    if not (form.data['surname'] or form.data['fullname']):
+        raise ValidationError('Enter a value for either surname or fullname')
+
+
 class AuthorForm(Form):
     """wtforms.Form representing an author."""
 
     # pylint: disable=missing-docstring,too-few-public-methods
 
-    forename = StringField("Forename", validators=[validators.Length(min=1),
-                                                   validators.Optional(),
-                                                   doesNotStartWithWildcard])
-    surname = StringField("Surname", validators=[validators.Length(min=1),
-                                                 doesNotStartWithWildcard])
+    forename = StringField("Forename", validators=[
+        validators.Length(min=1),
+        validators.Optional(strip_whitespace=True),
+        doesNotStartWithWildcard
+    ])
+    surname = StringField("Surname", validators=[doesNotStartWithWildcard])
+    fullname = StringField("Full name", validators=[validate_fullname,
+                                                    doesNotStartWithWildcard])
 
 
 class AuthorSearchForm(Form):

--- a/search/domain/author.py
+++ b/search/domain/author.py
@@ -6,13 +6,26 @@ class Author(Base):
     """Represents an author."""
 
     forename = Property('forename', str)
-    surname = Property('forensurnameame', str)
+    surname = Property('surname', str)
+    fullname = Property('fullname', str)
 
+    # TODO: gawd this is ugly.
     def __str__(self):
-        """Prints the author name."""
-        if self.forename:
-            return f'{self.forename} {self.surname}'
-        return self.surname
+        """Print the author name."""
+        if self.fullname and self.surname:
+            if self.forename:
+                name = f'{self.forename}[f] {self.surname}[s]'
+            else:
+                name = f'{self.surname}[s]'
+            name = f'{name} OR {self.fullname}'
+        elif self.fullname:
+            name = self.fullname
+        else:
+            if self.forename:
+                name = f'{self.forename}[f] {self.surname}[s]'
+            else:
+                name = f'{self.surname}[s]'
+        return name
 
 
 class AuthorList(list):
@@ -20,7 +33,11 @@ class AuthorList(list):
 
     def __str__(self):
         """Prints comma-delimited list of authors."""
-        return ', '.join([str(au) for au in self])
+        if len(self) == 0:
+            return ''
+        if len(self) > 1:
+            return ' AND '.join([f"({str(au)})" for au in self])
+        return str(self[0])
 
 
 class AuthorQuery(Query):

--- a/search/process/transform.py
+++ b/search/process/transform.py
@@ -37,15 +37,17 @@ def _constructACMClass(meta: DocMeta) -> list:
     return [obj.strip() for obj in raw.split(';')]
 
 
-def _update_with_initials(author: dict) -> dict:
+def _transformAuthor(author: dict) -> dict:
     fname = _strip_punctuation(author['first_name'])
     author['initials'] = [pt[0] for pt in fname.split() if pt]
+    author['full_name'] = f"{author['first_name']} {author['last_name']}"
     return author
 
 
 def _constructAuthors(meta: DocMeta) -> List[Dict]:
-    return [_update_with_initials(author)
+    return [_transformAuthor(author)
             for author in meta.get("authors_parsed", [])]
+
 
 TransformType = Union[str, Callable]
 _transformations: List[Tuple[str, TransformType]] = [

--- a/search/static/js/fieldset.js
+++ b/search/static/js/fieldset.js
@@ -43,6 +43,12 @@ $(function() {
                 $(this).val(default_value);
               }
           });
+
+          // Clear help text.
+          new_item.find(".help").each(function() {
+              $(this).empty();
+          });
+
           new_item.show();
           last_item.after(new_item); // Insert the new item below the last.
       });

--- a/search/templates/search/author_search.html
+++ b/search/templates/search/author_search.html
@@ -31,38 +31,57 @@
     {% endif %}
     <div class="box">
       <form method="GET" action="{{ url_for('ui.author_search') }}">
-
         {# Author search term fieldset. #}
         <section data-toggle="fieldset" id="authors-fieldset" class="section">
           {% for entry in form.authors.entries %}
-            <div class="field has-addons" data-toggle="fieldset-entry">
-              <div class="control is-expanded">
-                <label for="authors-{{loop.index0}}-forename" class="hidden-label">{{ entry.forename.label }}</label>
-                {{ entry.forename(class='input', placeholder="Forename or initial(s)")|safe }}
-                {% if entry.forename.errors %}
+            <div class="columns" data-toggle="fieldset-entry">
+              <div class="column is-gapless">
+                <div class="field has-addons">
+                  <div class="control is-expanded">
+                    <label for="authors-{{loop.index0}}-forename" class="hidden-label">{{ entry.forename.label }}</label>
+                    {{ entry.forename(class='input', placeholder="Forename or initial(s)")|safe }}
+                    {% if entry.forename.errors %}
+                      <div class="help is-warning">
+                        {% for error in entry.forename.errors %}{{ error }}{% endfor %}
+                      </div>
+                    {% endif %}
+                  </div>
+                  <div class="control is-expanded">
+                    <label for="authors-{{loop.index0}}-surname" class="hidden-label">{{ entry.surname.label }}</label>
+                    {{ entry.surname(class='input', placeholder="Surname")|safe }}
+                    {% if entry.surname.errors %}
+                      <div class="help is-warning">
+                        {% for error in entry.surname.errors %}{{ error }}{% endfor %}
+                      </div>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+              <div class="column is-gapless">
+                <div class="field has-addons">
+                  <span class="button is-static">OR</span>
+                  <div class="control is-expanded">
+                    <label for="authors-{{loop.index0}}-fullname" class="hidden-label">{{ entry.fullname.label }}</label>
+                    {{ entry.fullname(class='input', placeholder="Full name")|safe }}
+
+                  </div>
+                  <div class="control">
+                    <button type="button"
+                      data-toggle="fieldset-remove-row"
+                      id="authors-{{loop.index0}}-remove"
+                      class="button is-monospace fieldset-hidden-on-first-row"
+                      aria-label="Remove this search term"
+                      {% if loop.index0 == 0 %}style="visibility:hidden;"{% endif %}
+                      >–
+                    </button>
+                  </div>
+                </div>
+                {% if entry.fullname.errors %}
                   <div class="help is-warning">
-                    {% for error in entry.forename.errors %}{{ error }}{% endfor %}
+                    {% for error in entry.fullname.errors %}{{ error }}{% endfor %}
                   </div>
                 {% endif %}
-              </div>
-              <div class="control is-expanded">
-                <label for="authors-{{loop.index0}}-surname" class="hidden-label">{{ entry.surname.label }}</label>
-                {{ entry.surname(class='input', placeholder="Surname")|safe }}
-                {% if entry.surname.errors %}
-                  <div class="help is-warning">
-                    {% for error in entry.surname.errors %}{{ error }}{% endfor %}
-                  </div>
-                {% endif %}
-              </div>
-              <div class="control">
-                <button type="button"
-                  data-toggle="fieldset-remove-row"
-                  id="authors-{{loop.index0}}-remove"
-                  class="button is-monospace fieldset-hidden-on-first-row"
-                  aria-label="Remove this search term"
-                  {% if loop.index0 == 0 %}style="visibility:hidden;"{% endif %}
-                  >–
-                </button>
+
               </div>
             </div>
           {% endfor %}


### PR DESCRIPTION
There is now a dijunct full-name field on the search form....

![image](https://user-images.githubusercontent.com/3451594/36561604-37952052-17e2-11e8-8735-bd51a1623e09.png)

The ``full_name`` field has this mapping:

```json
            "full_name": {
              "type": "text",
              "analyzer": "folding"
            },
```

with a new analyzer:

```
        "folding": {
          "type": "custom",
          "tokenizer": "standard",
          "filter": [
            "icu_folding",
            "lowercase"
          ]
        },
```

Also changes the way that they query is displayed in the search results:

![image](https://user-images.githubusercontent.com/3451594/36561711-91d1d1a0-17e2-11e8-9c6a-d1c104f2c69f.png)
