### PR TITLE
ARXIVNG-322 padding whitespace is stripped from query

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,42 @@
 # arxiv-search
 
+## Testing & quality
+
+### Test suite
+Run the main test suite with...
+
+```bash
+nose2 --with-coverage
+```
+
+### Static checking
+Goal: zero errors/warnings.
+
+Use `# type: ignore` to disable mypy messages that do not reveal actual
+programming errors, and that are impractical to fix. If ignoring without
+verifying, insert a `# TODO: recheck`.
+
+If there is an active `mypy` GitHub issue (i.e. it's a bug/limitation in mypy)
+relevant to missed check, link that for later follow-up.
+
+```bash
+mypy --ignore-missing-imports -p search
+```
+
+### Documentation style
+Goal: zero errors/warnings.
+
+```bash
+pydocstyle --convention=numpy --add-ignore=D401 search
+```
+
+### Linting
+Goal: 9/10 or better.
+
+```bash
+pylint search
+```
+
 ## Documentation
 
 - Main service documentation: ``docs/``

--- a/search/controllers/advanced/forms.py
+++ b/search/controllers/advanced/forms.py
@@ -10,7 +10,7 @@ from wtforms import Form, BooleanField, StringField, SelectField, validators, \
 from wtforms.fields import HiddenField
 from wtforms import widgets
 
-from search.controllers.util import doesNotStartWithWildcard
+from search.controllers.util import doesNotStartWithWildcard, stripWhiteSpace
 
 
 class FieldForm(Form):
@@ -18,7 +18,8 @@ class FieldForm(Form):
 
     # pylint: disable=too-few-public-methods
 
-    term = StringField("Search term...", validators=[doesNotStartWithWildcard])
+    term = StringField("Search term...", filters=[stripWhiteSpace],
+                       validators=[doesNotStartWithWildcard])
     operator = SelectField("Operator", choices=[
         ('AND', 'AND'), ('OR', 'OR'), ('NOT', 'NOT')
     ], default='AND')

--- a/search/controllers/authors/forms.py
+++ b/search/controllers/authors/forms.py
@@ -8,7 +8,7 @@ from wtforms import Form, BooleanField, StringField, SelectField, validators, \
 from wtforms.fields import HiddenField
 from wtforms import widgets
 
-from search.controllers.util import doesNotStartWithWildcard
+from search.controllers.util import doesNotStartWithWildcard, stripWhiteSpace
 
 
 def validate_fullname(form: Form, field: StringField) -> None:
@@ -22,14 +22,18 @@ class AuthorForm(Form):
 
     # pylint: disable=missing-docstring,too-few-public-methods
 
-    forename = StringField("Forename", validators=[
-        validators.Length(min=1),
-        validators.Optional(strip_whitespace=True),
-        doesNotStartWithWildcard
-    ])
-    surname = StringField("Surname", validators=[doesNotStartWithWildcard])
-    fullname = StringField("Full name", validators=[validate_fullname,
-                                                    doesNotStartWithWildcard])
+    forename = StringField("Forename",
+                           validators=[
+                                validators.Length(min=1),
+                                validators.Optional(strip_whitespace=True),
+                                doesNotStartWithWildcard
+                           ],
+                           filters=[stripWhiteSpace])
+    surname = StringField("Surname", filters=[stripWhiteSpace],
+                          validators=[doesNotStartWithWildcard])
+    fullname = StringField("Full name", filters=[stripWhiteSpace],
+                           validators=[validate_fullname,
+                                       doesNotStartWithWildcard])
 
 
 class AuthorSearchForm(Form):

--- a/search/controllers/simple/forms.py
+++ b/search/controllers/simple/forms.py
@@ -8,7 +8,7 @@ from wtforms import Form, BooleanField, StringField, SelectField, validators, \
 from wtforms.fields import HiddenField
 from wtforms import widgets
 
-from search.controllers.util import doesNotStartWithWildcard
+from search.controllers.util import doesNotStartWithWildcard, stripWhiteSpace
 
 
 class SimpleSearchForm(Form):
@@ -30,6 +30,7 @@ class SimpleSearchForm(Form):
         ('author_id', 'Author ID')
     ])
     query = StringField('Search or Article ID',
+                        filters=[stripWhiteSpace],
                         validators=[doesNotStartWithWildcard])
     size = SelectField('results per page', default=25, choices=[
         ('25', '25'),

--- a/search/controllers/util.py
+++ b/search/controllers/util.py
@@ -9,3 +9,10 @@ def doesNotStartWithWildcard(form: Form, field: StringField) -> None:
         return
     if field.data.startswith('?') or field.data.startswith('*'):
         raise validators.ValidationError('Search cannot start with a wildcard')
+
+
+def stripWhiteSpace(value: str) -> str:
+    """Strip whitespace from form input."""
+    if not value:
+        return value
+    return value.strip()

--- a/tests/test_controller_advanced.py
+++ b/tests/test_controller_advanced.py
@@ -222,6 +222,18 @@ class TestAdvancedSearchForm(TestCase):
         form = AdvancedSearchForm(data)
         self.assertTrue(form.validate())
 
+    def test_input_whitespace_is_stripped(self):
+        """If query has padding whitespace, it should be removed."""
+        data = MultiDict({
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'title',
+            'terms-0-term': ' foo '
+        })
+        form = AdvancedSearchForm(data)
+        self.assertTrue(form.validate(), "Form should be valid.")
+        self.assertEqual(form.terms[0].term.data, 'foo',
+                         "Whitespace should be stripped.")
+
 
 class TestUpdatequeryWithClassification(TestCase):
     """:func:`.advanced._update_query_with_classification` adds classfnxn."""

--- a/tests/test_controller_authors.py
+++ b/tests/test_controller_authors.py
@@ -84,7 +84,6 @@ class TestSearchController(TestCase):
         self.assertIsInstance(call_args[0], AuthorQuery,
                               "An AuthorQuery is passed to the search index")
 
-
     @mock.patch('search.controllers.authors.index')
     def test_index_raises_query_error(self, mock_index):
         """Index service raises a QueryError."""
@@ -225,3 +224,16 @@ class TestQueryFromForm(TestCase):
         self.assertIsInstance(query, AuthorQuery,
                               "Should return an instance of AuthorQuery")
         self.assertIsNone(query.order, "Order should be None")
+
+    def test_input_whitespace_is_stripped(self):
+        """If query has padding whitespace, it should be removed."""
+        data = MultiDict({
+            'authors-0-forename': ' david ',
+            'authors-0-surname': ' davis ',
+            'authors-1-fullname': ' franklin '
+        })
+        form = AuthorSearchForm(data)
+        self.assertTrue(form.validate(), "Form should be valid.")
+        self.assertEqual(form.authors[0].forename.data, 'david')
+        self.assertEqual(form.authors[0].surname.data, 'davis')
+        self.assertEqual(form.authors[1].fullname.data, 'franklin')

--- a/tests/test_controller_simple.py
+++ b/tests/test_controller_simple.py
@@ -278,3 +278,13 @@ class TestQueryFromForm(TestCase):
         })
         form = SimpleSearchForm(data)
         self.assertFalse(form.validate(), "Form should be invalid")
+
+    def test_input_whitespace_is_stripped(self):
+        """If query has padding whitespace, it should be removed."""
+        data = MultiDict({
+            'searchtype': 'title',
+            'query': ' foo title '
+        })
+        form = SimpleSearchForm(data)
+        self.assertTrue(form.validate(), "Form should be valid.")
+        self.assertEqual(form.query.data, 'foo title')


### PR DESCRIPTION
Adds whitespace stripping to:
- Simple form
  - ``query``
- Author form
  - ``surname``
  - ``forename``
  - ``fullname``
- Advanced form
  - ``term``

Fixes #77