### PR TITLE
Add comma separator to thousands place in title

### DIFF
--- a/search/templates/search/advanced_search.html
+++ b/search/templates/search/advanced_search.html
@@ -281,6 +281,8 @@
         <p class="title is-6">Authors:</p>
           <ul>
             <li>Diacritic character variants are automatically searched in the Author(s) field.</li>
+            <li>To search multiple authors in the same Author(s) field, separate author names with a ; (semicolon).</li>
+            <li>Author names enclosed in quotes will be searched literally - exact matches only will be displayed.</li>
           </ul>
         <p class="title is-6">Dates:</p>
           <ul>
@@ -302,7 +304,7 @@
 
 {% block title %}
     {% if not show_form and results %}
-        Showing {{ metadata.start + 1 }}&ndash;{{ metadata.end }} of {{ metadata.total }} results
+        Showing {{ metadata.start + 1 }}&ndash;{{ metadata.end }} of {{ '{0:,}'.format(metadata.total) }} results
     {% elif show_form %}
         Advanced Search
     {% else %}

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -4,7 +4,7 @@
 
 {% block title %}
     {% if results %}
-        Showing {{ metadata.start + 1 }}&ndash;{{ metadata.end }} of {{ metadata.total }} results for {{ query.field }}: {{ query.value }}
+        Showing {{ metadata.start + 1 }}&ndash;{{ metadata.end }} of {{ '{0:,}'.format(metadata.total) }} results for {{ query.field }}: {{ query.value }}
     {% else %}
         Search
     {% endif %}
@@ -53,23 +53,33 @@
       <h2 class="title is-5">Tips</h2>
       <p class="title is-6">Wildcards:</p>
         <ul>
-         <li>use ? to replace a single character or * to replace any number of characters</li>
-         <li>can be used in any field, but not in the first character position</li>
+         <li>Use ? to replace a single character or * to replace any number of characters.</li>
+         <li>Can be used in any field, but not in the first character position. See Journal References tips for exceptions.</li>
         </ul>
-
       <p class="title is-6">Expressions:</p>
         <ul>
-           <li>TeX expressions can be searched, enclosed in single $</li>
+           <li>TeX expressions can be searched, enclosed in single $ characters.</li>
         </ul>
-      <p class="title is-6">Phrases</p>
+      <p class="title is-6">Phrases:</p>
         <ul>
           <li>Enclose phrases in double quotes for exact matches in title, abstract, and comments.</li>
-          <li>All journal reference searches are considered literal searches. E.g. a search for <strong>Physica A</strong> will match all papers with journal references containing <em>Physica A</em>, but a search for <strong>Physica A, 245 (1997) 181</strong> will only return the paper with journal reference <em>Physica A, 245 (1997) 181</em>.</li>
         </ul>
-
-      <p class="title is-6">Author Search:</p>
+      <p class="title is-6">Authors:</p>
         <ul>
-          <li>Diacritic character variants are automatically searched in the Author(s) field</li>
+          <li>Diacritic character variants are automatically searched in the Author(s) field.</li>
+          <li>To search multiple authors in the same Author(s) field, separate author names with a ; (semicolon).</li>
+          <li>Author names enclosed in quotes will be searched literally - exact matches only will be displayed.</li>
+        </ul>
+      <p class="title is-6">Dates:</p>
+        <ul>
+          <li>Search by date and sort by date will use a paper's submission date.</li>
+          <li>All versions of a paper are indexed and searchable, with the most recent version displayed first.</li>
+        </ul>
+      <p class="title is-6">Journal References:</p>
+        <ul>
+          <li>If a journal reference search contains a wildcard, matches will be made using wildcard matching as expected. For example, <strong>math*</strong> will match <em>math</em>, <em>maths</em>, <em>mathematics</em>.</li>
+          <li>If a journal reference search does <strong>not</strong> contain a wildcard, only exact phrases entered will be matched. For example, <strong>math</strong> would match <em>math</em> or <em>math and science</em> but not <em>maths</em> or <em>mathematics</em>.</li>
+          <li>All journal reference searches that do not contain a wildcard are literal searches: a search for <strong>Physica A</strong> will match all papers with journal references containing <em>Physica A</em>, but a search for <strong>Physica A, 245 (1997) 181</strong> will only return the paper with journal reference <em>Physica A, 245 (1997) 181</em>.</li>
         </ul>
     </div>
   {% endif %}


### PR DESCRIPTION
Screenshot taken doing testing on metadata.total+1000, since my test dataset doesn't have > 1,000 records.
![screen shot 2018-03-23 at 11 28 54 am](https://user-images.githubusercontent.com/17456668/37839031-d40fb352-2e8f-11e8-9b21-442e6f9d8122.png)
Plus opportunistic adjustments to help text (added author bits that will be included with ARXIVNG-372, and applied help tips from advanced to simple search for parity).