### PR TITLE
ARXIVNG-379 Order, page size, query propagate between pages

### DIFF
--- a/lintstats.sh
+++ b/lintstats.sh
@@ -14,8 +14,7 @@ curl -u $USERNAME:$GITHUB_TOKEN \
 
 
 # Check mypy integration
-pipenv run mypy --ignore-missing-imports -p search | grep -v "test"
-MYPY_STATUS=$?
+MYPY_STATUS=$( pipenv run mypy -p search | grep -v "test.*" | grep -v "defined here" | wc -l | tr -d '[:space:]' )
 if [ $MYPY_STATUS -ne 0 ]; then MYPY_STATE="failure" && echo "mypy failed"; else MYPY_STATE="success" &&  echo "mypy passed"; fi
 
 curl -u $USERNAME:$GITHUB_TOKEN \

--- a/search/controllers/advanced/forms.py
+++ b/search/controllers/advanced/forms.py
@@ -116,10 +116,10 @@ class AdvancedSearchForm(Form):
     terms = FieldList(FormField(FieldForm), min_entries=1)
     classification = FormField(ClassificationForm)
     date = FormField(DateForm)
-    size = SelectField('results per page', default=25, choices=[
-        ('25', '25'),
+    size = SelectField('results per page', default=50, choices=[
         ('50', '50'),
-        ('100', '100')
+        ('100', '100'),
+        ('200', '200')
     ])
     order = SelectField('Sort results by', choices=[
         ('-announced_date_first', 'Announcement date (newest first)'),

--- a/search/controllers/advanced/forms.py
+++ b/search/controllers/advanced/forms.py
@@ -127,6 +127,6 @@ class AdvancedSearchForm(Form):
         ('-submitted_date', 'Submission date (newest first)'),
         ('submitted_date', 'Submission date (oldest first)'),
         ('', 'Relevance')
-    ], validators=[validators.Optional()])
+    ], validators=[validators.Optional()], default='-announced_date_first')
     include_older_versions = BooleanField('Include older versions '
                                           'of papers in results')

--- a/search/controllers/advanced/forms.py
+++ b/search/controllers/advanced/forms.py
@@ -1,7 +1,7 @@
 """Provides form rendering and validation for the advanced search feature."""
 
 from datetime import date, datetime
-from typing import Callable, Optional, List
+from typing import Callable, Optional, List, Any
 
 from wtforms import Form, BooleanField, StringField, SelectField, validators, \
     FormField, SelectMultipleField, DateField, ValidationError, FieldList, \
@@ -19,7 +19,7 @@ class MultiFormatDateField(DateField):
     def __init__(self, label: Optional[str] = None,
                  validators: Optional[List[Callable]] = None,
                  formats: List[str] = ['%Y-%m-%d %H:%M:%S'],
-                 **kwargs) -> None:
+                 **kwargs: Any) -> None:
         """Override to change ``format: str`` to ``formats: List[str]``."""
         super(DateField, self).__init__(label, validators, **kwargs)
         self.formats = formats
@@ -34,6 +34,7 @@ class MultiFormatDateField(DateField):
         """Try date formats until one sticks, or raise ValueError."""
         if valuelist:
             date_str = ' '.join(valuelist)
+            self.data: Optional[date]
             for fmt in self.formats:
                 try:
                     self.data = datetime.strptime(date_str, fmt).date()

--- a/search/controllers/advanced/forms.py
+++ b/search/controllers/advanced/forms.py
@@ -1,7 +1,7 @@
 """Provides form rendering and validation for the advanced search feature."""
 
-from datetime import date
-from typing import Callable, Optional
+from datetime import date, datetime
+from typing import Callable, Optional, List
 
 from wtforms import Form, BooleanField, StringField, SelectField, validators, \
     FormField, SelectMultipleField, DateField, ValidationError, FieldList, \
@@ -11,6 +11,37 @@ from wtforms.fields import HiddenField
 from wtforms import widgets
 
 from search.controllers.util import doesNotStartWithWildcard, stripWhiteSpace
+
+
+class MultiFormatDateField(DateField):
+    """Extends :class:`.DateField` to support multiple date formats."""
+
+    def __init__(self, label: Optional[str] = None,
+                 validators: Optional[List[Callable]] = None,
+                 formats: List[str] = ['%Y-%m-%d %H:%M:%S'],
+                 **kwargs) -> None:
+        """Override to change ``format: str`` to ``formats: List[str]``."""
+        super(DateField, self).__init__(label, validators, **kwargs)
+        self.formats = formats
+
+    def _value(self) -> str:
+        if self.raw_data:
+            return ' '.join(self.raw_data)
+        else:
+            return self.data and self.data.strftime(self.formats[0]) or ''
+
+    def process_formdata(self, valuelist: List[str]) -> None:
+        """Try date formats until one sticks, or raise ValueError."""
+        if valuelist:
+            date_str = ' '.join(valuelist)
+            for fmt in self.formats:
+                try:
+                    self.data = datetime.strptime(date_str, fmt).date()
+                    return
+                except ValueError:
+                    continue
+            self.data = None
+            raise ValueError(self.gettext('Not a valid date value'))
 
 
 class FieldForm(Form):
@@ -85,11 +116,22 @@ class DateForm(Form):
         default='all_dates'
     )
 
-    year = DateField('Year', format='%Y',
-                     validators=[validators.Optional(), yearInBounds])
-    from_date = DateField('From',
-                          validators=[validators.Optional(), yearInBounds])
-    to_date = DateField('to', validators=[validators.Optional(), yearInBounds])
+    year = DateField(
+        'Year',
+        format='%Y',
+        validators=[validators.Optional(), yearInBounds]
+    )
+    from_date = MultiFormatDateField(
+        'From',
+        validators=[validators.Optional(), yearInBounds],
+        formats=['%Y-%m-%d', '%Y-%m', '%Y']
+
+    )
+    to_date = MultiFormatDateField(
+        'to',
+        validators=[validators.Optional(), yearInBounds],
+        formats=['%Y-%m-%d', '%Y-%m', '%Y']
+    )
 
     def validate_filter_by(self, field: RadioField) -> None:
         """Ensure that related fields are filled."""

--- a/search/controllers/simple/forms.py
+++ b/search/controllers/simple/forms.py
@@ -31,10 +31,10 @@ class SimpleSearchForm(Form):
     query = StringField('Search or Article ID',
                         filters=[stripWhiteSpace],
                         validators=[doesNotStartWithWildcard])
-    size = SelectField('results per page', default=25, choices=[
-        ('25', '25'),
+    size = SelectField('results per page', default=50, choices=[
         ('50', '50'),
-        ('100', '100')
+        ('100', '100'),
+        ('200', '200')
     ])
     order = SelectField('Sort results by', choices=[
         ('-announced_date_first', 'Announcement date (newest first)'),

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -1,7 +1,7 @@
 """Base domain classes for search service."""
 
 from typing import Any, Optional, List, Dict
-from datetime import datetime
+from datetime import datetime, date
 from operator import attrgetter
 from pytz import timezone
 import re
@@ -156,19 +156,19 @@ class SimpleQuery(Query):
 class Document:
     """A search document, representing an arXiv paper."""
 
+    submitted_date: Optional[datetime] = None
+    announced_date_first: Optional[date] = None
+    submitted_date_first: Optional[datetime] = None
+    submitted_date_latest: Optional[datetime] = None
+    submitted_date_all: List[str] = field(default_factory=list)
     id: str = field(default_factory=str)
     abstract: str = field(default_factory=str)
     abstract_tex: str = field(default_factory=str)
     authors: List[Dict] = field(default_factory=list)
     authors_freeform: str = field(default_factory=str)
     owners: List[Dict] = field(default_factory=list)
-    submitted_date: str = field(default_factory=str)
-    submitted_date_all: List[str] = field(default_factory=list)
-    submitted_date_first: str = field(default_factory=str)
-    submitted_date_latest: str = field(default_factory=str)
     modified_date: str = field(default_factory=str)
     updated_date: str = field(default_factory=str)
-    announced_date_first: str = field(default_factory=str)
     is_current: bool = True
     is_withdrawn: bool = False
     license: Dict[str, str] = field(default_factory=dict)

--- a/search/routes/ui.py
+++ b/search/routes/ui.py
@@ -1,12 +1,12 @@
-"""Provides REST API routes."""
+"""Provides the main search user interfaces."""
 
 from typing import Dict, Callable, Union, Any, Optional
 from functools import wraps
 from urllib.parse import urljoin, urlparse, parse_qs, urlencode, urlunparse
 
 from flask.json import jsonify
-from flask import Blueprint, render_template, redirect, request, url_for, \
-    Response
+from flask import Blueprint, render_template, redirect, request, Response, \
+    url_for
 from werkzeug.urls import Href, url_encode, url_parse, url_unparse, url_encode
 
 from arxiv import status
@@ -56,7 +56,6 @@ def advanced_search() -> Union[str, Response]:
     )
 
 
-# TODO: we need something more robust here; this is just to get us rolling.
 def _browse_url(name: str, **parameters: Any) -> Optional[str]:
     """Generate a URL for a browse route."""
     paper_id = parameters.get('paper_id')
@@ -73,7 +72,6 @@ def _browse_url(name: str, **parameters: Any) -> Optional[str]:
     return urljoin('https://arxiv.org', '/%s/%s' % (route, paper_id))
 
 
-# TODO: we need something more robust here; this is just to get us rolling.
 @blueprint.context_processor
 def external_url_builder() -> Dict[str, Callable]:
     """Add an external URL builder function to the template context."""

--- a/search/routes/ui.py
+++ b/search/routes/ui.py
@@ -127,3 +127,15 @@ def url_for_author_search_builder() -> Dict[str, Callable]:
         url: str = url_unparse(parts)
         return url
     return dict(url_for_author_search=url_for_author_search)
+
+
+@blueprint.context_processor
+def url_with_params_builder() -> Dict[str, Callable]:
+    """Inject a URL builder that handles GET parameters."""
+    def url_with_params(name: str, values: dict, params: dict) -> str:
+        """Build a URL for ``name`` with path ``values`` and GET ``params``."""
+        parts = url_parse(url_for(name, **values))
+        parts = parts.replace(query=url_encode(params))
+        url: str = url_unparse(parts)
+        return url
+    return dict(url_with_params=url_with_params)

--- a/search/services/index/__init__.py
+++ b/search/services/index/__init__.py
@@ -324,9 +324,10 @@ class SearchSession(object):
         # fields and configuration for highlighting.
         current_search = prepare.highlight(current_search)
 
-        with handle_es_exceptions():
+        with handle_es_exceptions():    
             # Slicing the search adds pagination parameters to the request.
             resp = current_search[query.page_start:query.page_end].execute()
+
 
         # Perform post-processing on the search results.
         return results.to_documentset(query, resp)

--- a/search/services/index/results.py
+++ b/search/services/index/results.py
@@ -1,11 +1,11 @@
 """Functions for processing search results (after execution)."""
 
 import re
-import bleach
 from datetime import datetime
 from math import floor
-from typing import Any
+from typing import Any, Dict
 
+import bleach
 from elasticsearch_dsl.response import Response
 from search.domain import Document, Query, DocumentSet
 from search import logging
@@ -62,7 +62,7 @@ def _start_safely(value: str, start: int, end: int, fragment_size: int,
 
 def _end_safely(value: str, remaining: int,
                 start_tag: str = HIGHLIGHT_TAG_OPEN,
-                end_tag: str = HIGHLIGHT_TAG_CLOSE):
+                end_tag: str = HIGHLIGHT_TAG_CLOSE) -> int:
     """Find a fragment end that doesn't break TeXisms or HTML."""
     # Should match on either a TeXism or a TeXism enclosed in highlight tags.
     ptn = r'(\$[^\$]+\$)|({}\$[^\$]+\${})'.format(start_tag, end_tag)
@@ -165,7 +165,7 @@ def _add_highlighting(result: dict, raw: Response) -> dict:
 def _to_document(raw: Response) -> Document:
     """Transform an ES search result back into a :class:`.Document`."""
     # typing: ignore
-    result = {'preview': {}}
+    result: Dict[str, Any] = {'preview': {}}
     for key in Document.fields():
         if not hasattr(raw, key):
             continue

--- a/search/services/index/results.py
+++ b/search/services/index/results.py
@@ -170,6 +170,8 @@ def _to_document(raw: Response) -> Document:
         if not hasattr(raw, key):
             continue
         value = getattr(raw, key)
+        if key == 'announced_date_first' and value and isinstance(value, str):
+            value = datetime.strptime(value, '%Y-%m').date()
         if key in ['submitted_date', 'submitted_date_first',
                    'submitted_date_latest']:
             try:

--- a/search/templates/search/advanced_search.html
+++ b/search/templates/search/advanced_search.html
@@ -228,6 +228,12 @@
                 {% endif %}
               </div>
             </div>
+            <div class="help has-text-grey is-size-7">
+              When limiting by date range, the lower bound of the "from" and "to" dates are
+              used. For example, searching with <code>From: 2012-02</code> and <code>To:
+              2013</code> will search for papers submitted from <code>2012-02-01</code> up to
+              (but not including) <code>2013-01-01</code>.
+            </div>
             <script>
               $('#date-to_date').focus(function() {
                 $('input[name="date-filter_by"]').attr('checked', false);

--- a/search/templates/search/advanced_search.html
+++ b/search/templates/search/advanced_search.html
@@ -269,7 +269,7 @@
             </div>
           </div>
         </section>
-        <input type="hidden" name="order" value="-announced_date_first">
+        <input type="hidden" name="order" value="{{ form.order.data }}">
         </form>
       </div>
     </div>
@@ -326,7 +326,11 @@
 {% block within_content %}
   <div class="is-clearfix" style="height: 2.5em"> {# TODO - adjust this layout so that it matches across all forms less awkwardly #}
     <div class="is-pulled-right">
-      <a href="{{ url_for('ui.search') }}">Simple Search</a>
+      {% if query %}
+      <a href="{{ url_with_params("ui.search", {}, {"order": query.order, "size": query.page_size}) }}">Simple Search</a>
+      {% else %}
+      <a href="{{ url_with_params("ui.search", {}, {"order": form.order.data, "size": form.size.data }) }}">Simple Search</a>
+      {% endif %}
     </div>
   </div>
 

--- a/search/templates/search/advanced_search.html
+++ b/search/templates/search/advanced_search.html
@@ -197,9 +197,9 @@
                 <div class="control">{{ form.date.from_date.label }}</div>
                 <div class="control">
                   {% if form.date.from_date.errors %}
-                  {{ form.date.from_date(placeholder="YYYY-MM-DD", class="input is-small is-danger")|safe }}
+                  {{ form.date.from_date(placeholder="YYYY[-MM[-DD]]", class="input is-small is-danger")|safe }}
                   {% else %}
-                  {{ form.date.from_date(placeholder="YYYY-MM-DD", class="input is-small")|safe }}
+                  {{ form.date.from_date(placeholder="YYYY[-MM[-DD]]", class="input is-small")|safe }}
                   {% endif %}
                 </div>
                 {% if form.date.from_date.errors %}
@@ -214,9 +214,9 @@
                 <div class="control">{{ form.date.to_date.label }}</div>
                 <div class="control">
                   {% if form.date.to_date.errors %}
-                  {{ form.date.to_date(placeholder="YYYY-MM-DD", class="input is-small is-danger")|safe }}
+                  {{ form.date.to_date(placeholder="YYYY[-MM[-DD]]", class="input is-small is-danger")|safe }}
                   {% else %}
-                  {{ form.date.to_date(placeholder="YYYY-MM-DD", class="input is-small")|safe }}
+                  {{ form.date.to_date(placeholder="YYYY[-MM[-DD]]", class="input is-small")|safe }}
                   {% endif %}
                 </div>
                 {% if form.date.to_date.errors %}

--- a/search/templates/search/search-macros.html
+++ b/search/templates/search/search-macros.html
@@ -191,7 +191,7 @@
     {% if result.comments %}
     <p class="comments is-size-7">
       <span class="has-text-black-bis has-text-weight-semibold">Comments:</span>
-      <span class="has-text-grey-dark">{% if result.highlight.comments %}{{ result.highlight.comments | safe }}{% else %}{{ result.comments }}{% endif %}</span>
+      <span class="has-text-grey-dark mathjax">{% if result.highlight.comments %}{{ result.highlight.comments | safe }}{% else %}{{ result.comments }}{% endif %}</span>
     </p>
     {% endif %}
 

--- a/search/templates/search/search-macros.html
+++ b/search/templates/search/search-macros.html
@@ -186,7 +186,7 @@
           <a class="is-size-7" onclick="document.getElementById('{{result.id}}-abstract-full').style.display = 'none'; document.getElementById('{{result.id}}-abstract-short').style.display = 'inline';">&#9651; Less</a>
         </span>
     </p>
-    <p class="is-size-7"><span class="has-text-black-bis has-text-weight-semibold">Submitted</span> {{ result.submitted_date.strftime('%-d %B, %Y') }}; {% if result.version > 1 %}<span class="has-text-black-bis has-text-weight-semibold">v1</span> submitted {{ result.submitted_date_first.strftime('%-d %B, %Y') }};{% endif %} <span class="has-text-black-bis has-text-weight-semibold">announced</span> {{ result.submitted_date.strftime('%B %Y') }}. {% if result.latest %}<span class="has-text-weight-bold">Latest version:</span> <a href="{{ external_url('browse', 'abstract', paper_id=result.latest) }}">{{ result.latest }}</a>.{% endif %}</p>
+    <p class="is-size-7"><span class="has-text-black-bis has-text-weight-semibold">Submitted</span> {{ result.submitted_date.strftime('%-d %B, %Y') }}; {% if result.version > 1 %}<span class="has-text-black-bis has-text-weight-semibold">v1</span> submitted {{ result.submitted_date_first.strftime('%-d %B, %Y') }};{% endif %} <span class="has-text-black-bis has-text-weight-semibold">originally announced</span> {{ result.announced_date_first.strftime('%B %Y') }}. {% if result.latest %}<span class="has-text-weight-bold">Latest version:</span> <a href="{{ external_url('browse', 'abstract', paper_id=result.latest) }}">{{ result.latest }}</a>.{% endif %}</p>
 
     {% if result.comments %}
     <p class="comments is-size-7">

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -39,13 +39,14 @@
     <div class="is-clearfix" style="height: 2.5em"> {# TODO - adjust this layout so that it matches across all forms less awkwardly #}
       <div class="is-pulled-right">
         {% if query %}
-        <a href="{{ url_for('ui.advanced_search') }}?terms-0-term={{ query.value }}&terms-0-field={{ query.field }}">Advanced Search</a>
+        <a href="{{ url_with_params("ui.advanced_search", {}, {"terms-0-term": query.value, "terms-0-field": query.field, "size": query.page_size, "order": query.order}) }}">Advanced Search</a>
         {% else %}
         <a href="{{ url_for('ui.advanced_search') }}">Advanced Search</a>
         {% endif %}
       </div>
     </div>
-    <input type="hidden" name="order" value="-announced_date_first">
+    <input type="hidden" name="order" value="{{ form.order.data }}">
+    <input type="hidden" name="size" value="{{ form.size.data }}">
   </form>
 
   {% if not results %}

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -38,7 +38,11 @@
     </div>
     <div class="is-clearfix" style="height: 2.5em"> {# TODO - adjust this layout so that it matches across all forms less awkwardly #}
       <div class="is-pulled-right">
+        {% if query %}
+        <a href="{{ url_for('ui.advanced_search') }}?terms-0-term={{ query.value }}&terms-0-field={{ query.field }}">Advanced Search</a>
+        {% else %}
         <a href="{{ url_for('ui.advanced_search') }}">Advanced Search</a>
+        {% endif %}
       </div>
     </div>
     <input type="hidden" name="order" value="-announced_date_first">


### PR DESCRIPTION
ARXIVNG-379
- After performing a simple search, when the user clicks on the "advanced search" link their query is used to auto-populate the advanced search form.
- When the user selects a page size and/or sort order, that selection is preserved across searches and search routes.

ARXIVNG-380
- Increased all page size options by 100%
- Set default page size to 50

ARXIVNG-382
- Added ``MultiFormatDateField`` to support variable-precision dates.
- Updated placeholder text in date range fields to ``YYYY[-MM[-DD]]``.

![image](https://user-images.githubusercontent.com/3451594/38148242-9aeba1be-3423-11e8-84ff-fb2211014e63.png)

