### PR TITLE
ARXIVNG-401 health check endpoint

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     test*
     wsgi.py
     populate_test_metadata.py
+    upload_static_assets.py
     create_index.py
     bulk_index.py
     shard_ids_for_index.py

--- a/search/controllers/__init__.py
+++ b/search/controllers/__init__.py
@@ -7,3 +7,35 @@ accepts a set of request parameters (``dict``-like) and returns a 3-tuple
 of response data (``dict``), status code (``int``), and extra response headers
 (``dict``).
 """
+from typing import Tuple, Dict, Any
+from arxiv import status
+from search.services import index
+from search.domain import SimpleQuery
+
+Response = Tuple[Dict[str, Any], int, Dict[str, Any]]
+
+
+def health_check() -> Response:
+    """
+    Exercise the connection with the search index with a real query.
+
+    Returns
+    -------
+    dict
+        Search result response data.
+    int
+        HTTP status code.
+    dict
+        Headers to add to the response.
+
+    """
+    try:
+        documentset = index.search(SimpleQuery(
+            field='all',
+            value='theory'
+        ))
+    except Exception as e:
+        return 'DOWN', status.HTTP_500_INTERNAL_SERVER_ERROR, {}
+    if documentset.results:
+        return 'OK', status.HTTP_200_OK, {}
+    return 'DOWN', status.HTTP_500_INTERNAL_SERVER_ERROR, {}

--- a/search/controllers/__init__.py
+++ b/search/controllers/__init__.py
@@ -12,10 +12,8 @@ from arxiv import status
 from search.services import index
 from search.domain import SimpleQuery
 
-Response = Tuple[Dict[str, Any], int, Dict[str, Any]]
 
-
-def health_check() -> Response:
+def health_check() -> Tuple[str, int, Dict[str, Any]]:
     """
     Exercise the connection with the search index with a real query.
 
@@ -30,10 +28,12 @@ def health_check() -> Response:
 
     """
     try:
-        documentset = index.search(SimpleQuery(
-            field='all',
-            value='theory'
-        ))
+        documentset = index.search(
+            SimpleQuery(   # type: ignore
+                search_field='all',
+                value='theory'
+            )
+        )
     except Exception as e:
         return 'DOWN', status.HTTP_500_INTERNAL_SERVER_ERROR, {}
     if documentset.results:

--- a/search/controllers/simple/__init__.py
+++ b/search/controllers/simple/__init__.py
@@ -185,7 +185,7 @@ def _query_from_form(form: SimpleSearchForm) -> SimpleQuery:
     :class:`.SimpleQuery`
     """
     q = SimpleQuery()
-    q.field = form.searchtype.data
+    q.search_field = form.searchtype.data
     q.value = form.query.data
     order = form.order.data
     if order and order != 'None':

--- a/search/controllers/tests.py
+++ b/search/controllers/tests.py
@@ -1,0 +1,36 @@
+from unittest import TestCase, mock
+
+from arxiv import status
+from search.domain import DocumentSet, Document
+from search.controllers import health_check
+
+
+class TestHealthCheck(TestCase):
+    """Tests for :func:`.health_check`."""
+
+    @mock.patch('search.controllers.index')
+    def test_index_is_down(self, mock_index):
+        """Test returns 'DOWN' + status 500 when index raises an exception."""
+        mock_index.search.side_effect = RuntimeError
+        response, status_code, _ = health_check()
+        self.assertEqual(response, 'DOWN', "Response content should be DOWN")
+        self.assertEqual(status_code, status.HTTP_500_INTERNAL_SERVER_ERROR,
+                         "Should return 500 status code.")
+
+    @mock.patch('search.controllers.index')
+    def test_index_returns_no_result(self, mock_index):
+        """Test returns 'DOWN' + status 500 when index returns no results."""
+        mock_index.search.return_value = DocumentSet({}, [])
+        response, status_code, _ = health_check()
+        self.assertEqual(response, 'DOWN', "Response content should be DOWN")
+        self.assertEqual(status_code, status.HTTP_500_INTERNAL_SERVER_ERROR,
+                         "Should return 500 status code.")
+
+    @mock.patch('search.controllers.index')
+    def test_index_returns_result(self, mock_index):
+        """Test returns 'OK' + status 200 when index returns results."""
+        mock_index.search.return_value = DocumentSet({}, [Document()])
+        response, status_code, _ = health_check()
+        self.assertEqual(response, 'OK', "Response content should be OK")
+        self.assertEqual(status_code, status.HTTP_200_OK,
+                         "Should return 200 status code.")

--- a/search/controllers/tests.py
+++ b/search/controllers/tests.py
@@ -1,3 +1,5 @@
+"""Tests for :mod:`search.controllers`."""
+
 from unittest import TestCase, mock
 
 from arxiv import status

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -120,10 +120,10 @@ class ClassificationList(list):
 class Query:
     """Represents a search query originating from the UI or API."""
 
-    order: Optional[str] = None
-    page_size: int = 25
-    page_start: int = 0
-    include_older_versions: bool = False
+    order: Optional[str] = field(default=None)
+    page_size: int = field(default=25)
+    page_start: int = field(default=0)
+    include_older_versions: bool = field(default=False)
 
     @property
     def page_end(self) -> int:
@@ -148,8 +148,8 @@ class Query:
 class SimpleQuery(Query):
     """Represents a simple search query."""
 
-    field: str = ''
-    value: str = ''
+    search_field: str = field(default_factory=str)
+    value: str = field(default_factory=str)
 
 
 @dataclass(init=True)

--- a/search/routes/ui.py
+++ b/search/routes/ui.py
@@ -57,7 +57,7 @@ def advanced_search() -> Union[str, Response]:
 
 
 @blueprint.route('status', methods=['GET', 'HEAD'])
-def status() -> Union[str, Response]:
+def service_status() -> Union[str, Response]:
     """
     Health check endpoint for search.
 

--- a/search/routes/ui.py
+++ b/search/routes/ui.py
@@ -12,7 +12,7 @@ from werkzeug.urls import Href, url_encode, url_parse, url_unparse, url_encode
 from arxiv import status
 from search import logging
 from werkzeug.exceptions import InternalServerError
-from search.controllers import simple, advanced
+from search.controllers import simple, advanced, health_check
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +54,16 @@ def advanced_search() -> Union[str, Response]:
         pagetitle="Advanced Search",
         **response
     )
+
+
+@blueprint.route('status', methods=['GET', 'HEAD'])
+def status() -> Union[str, Response]:
+    """
+    Health check endpoint for search.
+
+    Exercises the search index connection with a real query.
+    """
+    return health_check()
 
 
 def _browse_url(name: str, **parameters: Any) -> Optional[str]:

--- a/search/services/index/__init__.py
+++ b/search/services/index/__init__.py
@@ -302,7 +302,6 @@ class SearchSession(object):
             Invalid query parameters.
 
         """
-
         # Make sure that the user is not requesting a nonexistant page.
         max_pages = int(MAX_RESULTS/query.page_size)
         if query.page > max_pages:

--- a/search/services/index/__init__.py
+++ b/search/services/index/__init__.py
@@ -329,7 +329,6 @@ class SearchSession(object):
             # Slicing the search adds pagination parameters to the request.
             resp = current_search[query.page_start:query.page_end].execute()
 
-
         # Perform post-processing on the search results.
         return results.to_documentset(query, resp)
 

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -186,12 +186,12 @@ def _fielded_terms_to_q(query: AdvancedQuery) -> Match:
 def simple(search: Search, query: SimpleQuery) -> Search:
     """Prepare a :class:`.Search` from a :class:`.SimpleQuery`."""
     search = search.filter("term", is_current=True)
-    if query.field == 'all':
+    if query.search_field == 'all':
         q_ar = [_field_term_to_q(field, query.value)
                 for field in ALL_SEARCH_FIELDS]
         q = reduce(ior, q_ar)
     else:
-        q = _field_term_to_q(query.field, query.value)
+        q = _field_term_to_q(query.search_field, query.value)
     search = search.query(q)
     search = _apply_sort(query, search)
     return search

--- a/search/services/index/results.py
+++ b/search/services/index/results.py
@@ -120,13 +120,14 @@ def _preview(value: str, fragment_size: int = 400,
     # For paranoia's sake, make sure that no other HTML makes it through.
     # This will also clean up any unbalanced tags, in case we screwed up
     # generating the preview.
-    snippet = bleach.clean(value[start:end].strip(),
-                           tags=['span'], attributes={'span': 'class'})
-    return (
+    snippet: str = bleach.clean(value[start:end].strip(),
+                                tags=['span'], attributes={'span': 'class'})
+    snippet = (
         ('&hellip;' if start > 0 else '')
         + snippet
         + ('&hellip;' if end < len(value) else '')
     )
+    return snippet
 
 
 def _add_highlighting(result: dict, raw: Response) -> dict:

--- a/search/services/index/tests/tests.py
+++ b/search/services/index/tests/tests.py
@@ -105,7 +105,7 @@ class TestSearch(TestCase):
         query = SimpleQuery(
             order='relevance',
             page_size=10,
-            field='title',
+            search_field='title',
             value='foo title'
         )
         document_set = index.search(query)

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -4,7 +4,7 @@
 
 {% block title %}
     {% if results %}
-        Showing {{ metadata.start + 1 }}&ndash;{{ metadata.end }} of {{ '{0:,}'.format(metadata.total) }} results for {{ query.field }}: <span class="mathjax">{{ query.value }}</span>
+        Showing {{ metadata.start + 1 }}&ndash;{{ metadata.end }} of {{ '{0:,}'.format(metadata.total) }} results for {{ query.search_field }}: <span class="mathjax">{{ query.value }}</span>
     {% else %}
         Search
     {% endif %}
@@ -39,7 +39,7 @@
     <div class="is-clearfix" style="height: 2.5em"> {# TODO - adjust this layout so that it matches across all forms less awkwardly #}
       <div class="is-pulled-right">
         {% if query %}
-        <a href="{{ url_with_params("ui.advanced_search", {}, {"terms-0-term": query.value, "terms-0-field": query.field, "size": query.page_size, "order": query.order}) }}">Advanced Search</a>
+        <a href="{{ url_with_params("ui.advanced_search", {}, {"terms-0-term": query.value, "terms-0-field": query.search_field, "size": query.page_size, "order": query.order}) }}">Advanced Search</a>
         {% else %}
         <a href="{{ url_for('ui.advanced_search') }}">Advanced Search</a>
         {% endif %}
@@ -52,7 +52,7 @@
   {% if not results %}
     {% if query %}
       <p class="is-size-4 has-text-warning">
-        Sorry, your query for <span class="is-warning">{{ query.field }}: {{ query.value }}</span> produced no results.
+        Sorry, your query for <span class="is-warning">{{ query.search_field }}: {{ query.value }}</span> produced no results.
       </p>
     {% endif %}
     <div class="box">


### PR DESCRIPTION
This is pretty bare-bones. If we need to return more information, we can do that. The requirements for Kubernetes liveness are [pretty simple](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-http-request), and this PR meets those.