### PR TITLE
ARXIVNG-418 fixed wildcard search, changed default querystring behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
 cache: pip
 os:
   - linux
+env:
+  - LOGLEVEL: "40"
 python:
   - "3.6"
 script:

--- a/README.md
+++ b/README.md
@@ -167,9 +167,6 @@ agent            | application 12/Apr/2018:15:49:25 +0000 - search.agent.consume
 agent            | application 12/Apr/2018:15:49:25 +0000 - search.agent.consumer - None - [arxiv:null] - INFO: "Processing record 49583482484923667520018808447541811167076420804939874306"
 ```
 
-
-
-
 ## Deploying static assets to S3
 
 Assets in search/static can be deployed to S3 using the included
@@ -185,15 +182,21 @@ set ``FLASKS3_ACTIVE=1`` when starting the Flask dev server.
 Install testing tools with...
 
 ```bash
-pip install -r requirements/test.txt
+pipenv install --dev
 ```
 
 ### Test suite
 Run the main test suite with...
 
 ```bash
-pipenv install --dev
 pipenv run nose2 --with-coverage
+```
+
+To include integration tests, the environment variable ``WITH_INTEGRATION``.
+E.g.
+
+```bash
+WITH_INTEGRATION=1 pipenv run nose2 --with-coverage
 ```
 
 ### Static checking

--- a/search/agent/__init__.py
+++ b/search/agent/__init__.py
@@ -9,6 +9,7 @@ available. Each version is passed to the :mod:`search.services.index` service,
 and becomes available for discovery via :mod:`search.routes.ui`.
 """
 from typing import Optional
+from datetime import datetime
 import warnings
 from .consumer import MetadataRecordProcessor, DocumentFailed, IndexingFailed
 from .base import CheckpointManager
@@ -20,7 +21,8 @@ logger = logging.getLogger(__name__)
 logger.propagate = False
 
 
-def process_stream(duration: Optional[int] = None) -> None:
+def process_stream(duration: Optional[int] = None,
+                   start_at: Optional[datetime] = datetime.now()) -> None:
     """
     Configure and run the record processor.
 
@@ -52,6 +54,7 @@ def process_stream(duration: Optional[int] = None) -> None:
             endpoint=app.config.get('KINESIS_ENDPOINT', None),
             verify=app.config.get('KINESIS_VERIFY', 'true') == 'true',
             duration=duration,
-            cache_dir=cache_dir
+            cache_dir=cache_dir,
+            start_at=start_at
         )
         processor.go()

--- a/search/agent/base.py
+++ b/search/agent/base.py
@@ -8,7 +8,7 @@ import time
 import json
 from datetime import datetime, timedelta
 import os
-from typing import Any, Optional, Tuple, Generator, Callable
+from typing import Any, Optional, Tuple, Generator, Callable, Dict
 from contextlib import contextmanager
 import signal
 
@@ -224,7 +224,10 @@ class BaseConsumer(object):
             The sequence ID of the record on which to start.
 
         """
-        params = dict(StreamName=self.stream_name, ShardId=self.shard_id)
+        params: Dict[str, Any] = dict(
+            StreamName=self.stream_name,
+            ShardId=self.shard_id
+        )
         if self.position:
             params.update(dict(
                 ShardIteratorType='AFTER_SEQUENCE_NUMBER',

--- a/search/agent/base.py
+++ b/search/agent/base.py
@@ -71,6 +71,7 @@ def retry(retries: int = 5, wait: int = 5) -> Callable:
                 except ClientError as e:
                     code = e.response['Error']['Code']
                     logger.error('Caught ClientError %s, retrying', code)
+                    time.sleep(wait)
                     retries -= 1
             raise KinesisRequestFailed('Max retries; last code: {code}')
         return inner
@@ -135,6 +136,7 @@ class BaseConsumer(object):
         self.start_time = None
         self.back_off = back_off
         self.batch_size = batch_size
+        self.sleep_time = 5
 
         if not self.stream_name or not self.shard_id:
             logger.info(
@@ -272,6 +274,7 @@ class BaseConsumer(object):
         logger.debug(f'Get more records, starting at {start}')
         processed = 0
         try:
+            time.sleep(self.sleep_time)   # Don't get carried away.
             next_start, response = self.get_records(start, self.batch_size)
         except Exception as e:
             self._checkpoint()

--- a/search/agent/base.py
+++ b/search/agent/base.py
@@ -280,6 +280,7 @@ class BaseConsumer(object):
             self._checkpoint()
             raise StopProcessing('Unhandled exception: %s' % str(e)) from e
 
+        logger.debug('Got %i records', len(response['Records']))
         for record in response['Records']:
             self._check_timeout()
 

--- a/search/agent/tests/test_base_consumer.py
+++ b/search/agent/tests/test_base_consumer.py
@@ -50,9 +50,9 @@ class TestBaseConsumer(TestCase):
         mock_client = mock.MagicMock()
         mock_client_factory.return_value = mock_client
         mock_client.get_records.return_value = {
-            'Records': (
+            'Records': [
                 {'SequenceNumber': str(i)} for i in range(10)
-            ),
+            ],
             'NextShardIterator': '10'
         }
         consumer = BaseConsumer('foo', '1', 'a1b2c3d4', 'qwertyuiop',
@@ -75,9 +75,9 @@ class TestBaseConsumer(TestCase):
             if start > 500:
                 return {'Records': [], 'NextShardIterator': None}
             return {
-                'Records': (
+                'Records': [
                     {'SequenceNumber': str(i)} for i in range(start, end)
-                ),
+                ],
                 'NextShardIterator': str(end + 1)
             }
 

--- a/search/agent/tests/tests.py
+++ b/search/agent/tests/tests.py
@@ -21,6 +21,8 @@ BASE_PATH = os.path.join(os.path.split(os.path.abspath(__file__))[0],
 class TestKinesisIntegration(TestCase):
     """Test :class:`.MetadataRecordProcessor` with a live Kinesis stream."""
 
+    __test__ = int(bool(os.environ.get('WITH_INTEGRATION', False)))
+
     @classmethod
     def setUpClass(cls):
         """Spin up ES and index documents."""
@@ -34,6 +36,12 @@ class TestKinesisIntegration(TestCase):
         os.environ['KINESIS_CHECKPOINT_VOLUME'] = tempfile.mkdtemp()
         os.environ['KINESIS_ENDPOINT'] = 'http://127.0.0.1:6568'
         os.environ['KINESIS_VERIFY'] = 'false'
+
+        print('pulling localstack image')
+        pull_localstack = subprocess.run(
+            "docker pull atlassianlabs/localstack",
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+        )
 
         print('starting localstack')
         start_localstack = subprocess.run(
@@ -112,7 +120,7 @@ class TestKinesisIntegration(TestCase):
         mock_metadata.BadResponse = metadata.BadResponse
 
         try:
-            process_stream(duration=30)
+            process_stream(duration=30, start_at=None)
         except StopProcessing:
             pass
 

--- a/search/agent/tests/tests.py
+++ b/search/agent/tests/tests.py
@@ -32,18 +32,18 @@ class TestKinesisIntegration(TestCase):
         os.environ['KINESIS_STREAM'] = 'MetadataIsAvailable'
         os.environ['KINESIS_SHARD_ID'] = '0'
         os.environ['KINESIS_CHECKPOINT_VOLUME'] = tempfile.mkdtemp()
-        os.environ['KINESIS_ENDPOINT'] = 'http://127.0.0.1:5568'
+        os.environ['KINESIS_ENDPOINT'] = 'http://127.0.0.1:6568'
         os.environ['KINESIS_VERIFY'] = 'false'
 
         print('starting localstack')
         start_localstack = subprocess.run(
-            "docker run -d -p 5568:4568 atlassianlabs/localstack",
+            "docker run -d -p 6568:4568 --name ltest atlassianlabs/localstack",
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 
         if start_localstack.returncode != 0:
             raise RuntimeError(
                 f'Could not start localstack: {start_localstack.stdout}.'
-                f' Is one already running? Is port 5568 available?'
+                f' Is one already running? Is port 6568 available?'
             )
         cls.ls_container = start_localstack.stdout.decode('ascii').strip()
         print(f'localstack started as {cls.ls_container}')
@@ -51,7 +51,7 @@ class TestKinesisIntegration(TestCase):
         cls.client = boto3.client(
             'kinesis',
             region_name='us-east-1',
-            endpoint_url="http://localhost:5568",
+            endpoint_url="http://localhost:6568",
             aws_access_key_id='foo',
             aws_secret_access_key='bar',
             verify=False

--- a/search/agent/tests/tests.py
+++ b/search/agent/tests/tests.py
@@ -112,7 +112,7 @@ class TestKinesisIntegration(TestCase):
         mock_metadata.BadResponse = metadata.BadResponse
 
         try:
-            process_stream(duration=5)
+            process_stream(duration=30)
         except StopProcessing:
             pass
 

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -75,7 +75,7 @@ def _field_term_to_q(field: str, term: str) -> Q:
     term_sans_tex = strip_tex(term).lower()
     # These terms have fields for both TeX and English normalization.
     if field in ['title', 'abstract']:
-        qr = (
+        return (
             Q("query_string", fields=[
                 field,
                 f'{field}_utf8',
@@ -90,8 +90,6 @@ def _field_term_to_q(field: str, term: str) -> Q:
             # prefer them to partial matches within TeXisms.
             | Q("match", **{f'{field}.tex': {'query': term, 'boost': 2}})
         )
-        print(qr)
-        return qr
 
     # These terms have no additional fields.
     elif field in ['comments']:

--- a/tests/integration/test_search_integration.py
+++ b/tests/integration/test_search_integration.py
@@ -24,7 +24,7 @@ EASTERN = timezone('US/Eastern')
 class TestSearchIntegration(TestCase):
     """Indexes a limited set of documents, and tests search behavior."""
 
-    __test__ = int(os.environ.get('TEST_LEVEL', '1')) >= 2
+    __test__ = int(bool(os.environ.get('WITH_INTEGRATION', False)))
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
https://github.com/cul-it/arxiv-search/issues/151 was occurring because we (at some point) switched to ``simple_query_string`` queries for title and abstract, and ``simple_query_string`` does not support the ``?`` wildcard operator (only ``*``). Switching to ``query_string`` fixes this.

Given https://github.com/cul-it/arxiv-search/issues/143 (which is reasonable), I switched the ``default_operator`` to ``AND``. 

Note that using the ``query_string`` does open up some additional functionality for users (e.g. using parens to group terms, boolean operators, etc).  Since this only applies to title and abstract, I'm not sure whether we want to actually document this, or let them discover it on their own. I'm leaning toward the latter.

Note that this was branched from ``task/ARXIVNG-419``, so it includes changes from https://github.com/cul-it/arxiv-search/pull/154 which should be merged first.