### PR TITLE
ARXIVNG-552 escaping special characters correctly, removed string coercion from wsgi wrapper

### DIFF
--- a/search/controllers/advanced/forms.py
+++ b/search/controllers/advanced/forms.py
@@ -170,6 +170,6 @@ class AdvancedSearchForm(Form):
         ('-submitted_date', 'Submission date (newest first)'),
         ('submitted_date', 'Submission date (oldest first)'),
         ('', 'Relevance')
-    ], validators=[validators.Optional()], default='-announced_date_first')
+    ], validators=[validators.Optional()], default='')
     include_older_versions = BooleanField('Include older versions '
                                           'of papers in results')

--- a/search/controllers/simple/__init__.py
+++ b/search/controllers/simple/__init__.py
@@ -120,6 +120,9 @@ def search(request_params: dict) -> Response:
                 "search again.  If this problem persists, please report it to "
                 "help@arxiv.org."
             ) from e
+        except Exception as e:
+            print(e)
+            raise 
     else:
         logger.debug('form is invalid: %s', str(form.errors))
         if 'order' in form.errors or 'size' in form.errors:

--- a/search/controllers/simple/forms.py
+++ b/search/controllers/simple/forms.py
@@ -42,7 +42,7 @@ class SimpleSearchForm(Form):
         ('-submitted_date', 'Submission date (newest first)'),
         ('submitted_date', 'Submission date (oldest first)'),
         ('', 'Relevance')
-    ], validators=[validators.Optional()], default='-announced_date_first')
+    ], validators=[validators.Optional()], default='')
 
     def validate_query(form: Form, field: StringField) -> None:
         """Validate the length of the querystring, if searchtype is set."""

--- a/search/services/index/__init__.py
+++ b/search/services/index/__init__.py
@@ -92,9 +92,6 @@ def handle_es_exceptions() -> Generator:
 class SearchSession(object):
     """Encapsulates session with Elasticsearch host."""
 
-    # TODO: we need to take on security considerations here. Presumably we will
-    # use SSL. Presumably we will use HTTP Auth, or something else.
-
     def __init__(self, host: str, index: str, port: int=9200,
                  scheme: str='http', user: Optional[str]=None,
                  password: Optional[str]=None, mapping: Optional[str]=None,

--- a/search/services/index/authors.py
+++ b/search/services/index/authors.py
@@ -9,8 +9,11 @@ def _parseName(au_safe: str) -> Tuple[str, Optional[str]]:
     """Parse a name string into its (likely) constituent parts."""
     # We interpret the comma as separating the surname from the forename.
     if "," in au_safe:
-        surname, forename = au_safe.split(',')
-        return surname.strip(), forename.strip()
+        au_parts = au_safe.split(',')
+        if len(au_parts) >= 2:
+            surname = au_parts[0]
+            forename = au_parts[1]
+            return surname.strip(), forename.strip()
 
     # Otherwise, treat the last word in the name as the surname. This isn't
     # a great approach from first principles, but it produces reasonable

--- a/wsgi.py
+++ b/wsgi.py
@@ -6,7 +6,5 @@ import os
 
 def application(environ, start_response):
     """WSGI application factory."""
-    for key, value in environ.items():
-        os.environ[key] = str(value)
     app = create_ui_web_app()
     return app(environ, start_response)


### PR DESCRIPTION
To provide better support for special characters, we should consider a different tokenizer for non-keyword fields. Until then, this will at least allow the search to proceed, even if the special characters don't make it past the analyzer.