### PR TITLE
ARXIVNG-549 suppress stopwords in author search

### DIFF
--- a/search/services/index/authors.py
+++ b/search/services/index/authors.py
@@ -76,7 +76,7 @@ def construct_author_query(term: str) -> Q:
             # Matching on keyword field is effectively an exact match.
             Q('match', **{
                 'authors__full_name__exact': {
-                    'query': fullname_safe, 'boost': 10
+                    'query': fullname_safe, 'boost': 30
                 },
             })
 

--- a/search/services/index/authors.py
+++ b/search/services/index/authors.py
@@ -9,6 +9,7 @@ from .util import wildcardEscape, is_literal_query, Q_, escape
 
 STOP = ["and", "or", "the", "of", "a", "for", "an"]
 
+
 # TODO: remove this when we address the author name bug in
 # search.process.transform..
 def _strip_punctuation(s: str) -> str:
@@ -60,13 +61,14 @@ def construct_author_query(term: str) -> Q:
         au_name, has_wildcard = wildcardEscape(au_name)
         au_safe = au_name.replace('*', '').replace('?', '').replace('"', '')
         surname_safe, forename_safe = _parseName(au_safe)
-        # TODO: remove this when the author name bug is fixed in
-        # search.process.transform. Since we are erroneously removing
-        # punctuation from author names prior to indexing, it's important to do
-        # the same here so that results are returned.
-        forename_safe = _strip_punctuation(forename_safe)
 
         if forename_safe is not None:
+            # TODO: remove this when the author name bug is fixed in
+            # search.process.transform. Since we are erroneously removing
+            # punctuation from author names prior to indexing, it's important
+            # to do the same here so that results are returned.
+            forename_safe = _strip_punctuation(forename_safe)
+
             fullname_safe = f'{forename_safe} {surname_safe}'
         else:
             fullname_safe = surname_safe

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -217,10 +217,11 @@ def simple(search: Search, query: SimpleQuery) -> Search:
         q_ar = [_field_term_to_q(field, query.value)
                 for field in use]
         q = reduce(ior, q_ar)
+
         if not is_literal_query(query.value):
             # When searching in "all fields", users will include terms from
             # various different fields. This additional multi-match treats
-            # title, abstract, and authors as one big field, and boosts
+            # title and abstract as one big field, and boosts
             # matching results. Since authors get boosted strongly elsewhere,
             # this effectively surfaces results for which authors respond and
             # also titles (and, to a lesser extent, abstracts) respond.
@@ -229,7 +230,6 @@ def simple(search: Search, query: SimpleQuery) -> Search:
                    query=query.value, boost=4, type="cross_fields")
     else:
         q = _field_term_to_q(query.search_field, query.value)
-    print(q)
     search = search.query(q)
     search = _apply_sort(query, search)
     return search

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -83,13 +83,18 @@ def _field_term_to_q(field: str, term: str) -> Q:
         # prefer them to partial matches within TeXisms.
         if is_tex_query(term):
             return Q("match", **{f'{field}.tex': {'query': term, 'boost': 2}})
+
+        # "english" fields are analyzed with the English stoplist, so they're
+        # safe for all kinds of searches.
+        _fields = [f'{field}.english', f'{field}_utf8__english']
+
+        # If this is a literal query, however, we should search against the
+        # the base field, too.
+        if is_literal_query(term_sans_tex):
+            _fields += [field, f'{field}_utf8']
+
         q = (
-            Q("query_string", fields=[
-                field,
-                f'{field}_utf8',
-                f'{field}__english',
-                f'{field}_utf8__english'
-              ],
+            Q("query_string", fields=_fields,
               default_operator='AND',
               analyze_wildcard=True,
               allow_leading_wildcard=False,
@@ -193,8 +198,8 @@ def _fielded_terms_to_q(query: AdvancedQuery) -> Match:
                 # authors respond and also titles (and, to a lesser extent,
                 # abstracts) respond.
                 q |= Q("multi_match",
-                       fields=["title*^30", "abstract*^10", "authors*"],
-                       query=escape(term.term), boost=4, type="cross_fields")
+                       fields=["title.english^30", "abstract.english*^10"],
+                       query=term.term, boost=4, type="cross_fields")
         else:
             q = _field_term_to_q(term.field, term.term)
 
@@ -220,11 +225,11 @@ def simple(search: Search, query: SimpleQuery) -> Search:
             # this effectively surfaces results for which authors respond and
             # also titles (and, to a lesser extent, abstracts) respond.
             q |= Q("multi_match",
-                   fields=["title*^30", "abstract*^10", "authors*"],
+                   fields=["title.english^30", "abstract.english*^10"],
                    query=query.value, boost=4, type="cross_fields")
-            pass
     else:
         q = _field_term_to_q(query.search_field, query.value)
+    print(q)
     search = search.query(q)
     search = _apply_sort(query, search)
     return search
@@ -261,6 +266,7 @@ def highlight(search: Search) -> Search:
         post_tags=[HIGHLIGHT_TAG_CLOSE]
     )
     search = search.highlight('title', type='plain', number_of_fragments=0)
+    search = search.highlight('title.english', type='plain', number_of_fragments=0)
     search = search.highlight('title.tex', type='plain', number_of_fragments=0)
     search = search.highlight('title_utf8', type='plain',
                               number_of_fragments=0)
@@ -279,4 +285,6 @@ def highlight(search: Search) -> Search:
     search = search.highlight('abstract', type='plain', number_of_fragments=0)
     search = search.highlight('abstract.tex', type='plain',
                               number_of_fragments=0)
+    search = search.highlight('abstract.english', type='plain',
+                               number_of_fragments=0)
     return search

--- a/search/services/index/results.py
+++ b/search/services/index/results.py
@@ -148,7 +148,8 @@ def _add_highlighting(result: dict, raw: Response) -> dict:
         # To guard against this while preserving highlighting, we move
         # any highlighting tags from within TeXisms to encapsulate the
         # entire TeXism.
-        if field in ['title', 'title_utf8', 'abstract']:
+        if field in ['title', 'title_utf8', 'title.english', 'abstract',
+                     'abstract.english']:
             value = _highlight_whole_texism(value)
 
         # A hit on authors may originate in several different fields, most
@@ -168,12 +169,17 @@ def _add_highlighting(result: dict, raw: Response) -> dict:
             result['highlight'][field] = \
                 result['highlight'].pop(f'{field}.tex')
 
-    for field in ['abstract.tex', 'abstract_utf8', 'abstract']:
+    for field in ['abstract.tex', 'abstract.english', 'abstract_utf8',
+                  'abstract']:
         if field in result['highlight']:
             value = result['highlight'][field]
             abstract_snippet = _preview(value)
             result['preview']['abstract'] = abstract_snippet
             result['highlight']['abstract'] = value
+            break
+    for field in ['title.english', 'title_utf8', 'title']:
+        if field in result['highlight']:
+            result['highlight']['title'] = result['highlight'][field]
             break
     return result
 


### PR DESCRIPTION
This also provides a short-term fix for ARXIVNG-543, which is due to erroneous stripping of punctuation characters from author names. The least we can do is process the query in the same way that we prepared the search document. This is *not* a long-term fix.

@eawoods Eager to hear if this improves some of the cases that you were looking at.