### PR TITLE
ARXIVNG-544 ARXIVNG-549 ARXIVNG-552 refactored query-building for simplicity, clarity

### DIFF
--- a/mappings/DocumentMapping.json
+++ b/mappings/DocumentMapping.json
@@ -174,6 +174,7 @@
               "type": "text",
               "analyzer": "author_folding",
               "similarity": "classic",
+              "copy_to": ["combined", "authors_combined"],
               "fields": {
                 "exact": {
                     "type": "keyword",
@@ -185,6 +186,7 @@
               "type": "text",
               "analyzer": "author_folding",
               "similarity": "classic",
+              "copy_to": ["combined", "authors_combined"],
               "fields": {
                 "exact": {
                     "type": "keyword",
@@ -248,12 +250,13 @@
               "type": "text",
               "analyzer": "author_folding",
               "similarity": "classic",
-              "copy_to": ["combined"]
+              "copy_to": ["combined", "authors_combined"]
             },
             "full_name_initialized": {
               "type": "text",
               "analyzer": "author_folding",
-              "similarity": "classic"
+              "similarity": "classic",
+              "copy_to": ["combined", "authors_combined"]
             },
             "suffix": {
               "type": "keyword"
@@ -513,6 +516,10 @@
         "combined": {
           "type": "text",
           "analyzer": "combined"
+        },
+        "authors_combined": {
+          "type": "text",
+          "analyzer": "author_folding"
         }
       }
     }

--- a/mappings/DocumentMapping.json
+++ b/mappings/DocumentMapping.json
@@ -23,11 +23,15 @@
       "analyzer": {
         "combined": {
           "type": "custom",
-          "tokenizer": "standard",
+          "tokenizer": "whitespace",
           "filter": [
+            "icu_folding",
             "lowercase",
             "english_stop",
-            "german_normalization"
+            "german_normalization",
+            "scandinavian_normalization",
+            "scandinavian_folding",
+            "serbian_normalization"
           ]
         },
         "simple": {
@@ -47,14 +51,6 @@
             "english_stop"
           ]
         },
-        "author_simple": {
-          "type": "custom",
-          "tokenizer": "whitespace",
-          "filter": [
-            "lowercase",
-            "german_normalization"
-          ]
-        },
         "author_folding": {
           "type": "custom",
           "tokenizer": "whitespace",
@@ -64,7 +60,10 @@
           "filter": [
             "icu_folding",
             "lowercase",
-            "german_normalization"
+            "german_normalization",
+            "scandinavian_normalization",
+            "scandinavian_folding",
+            "serbian_normalization"
           ]
         },
         "tex_analyzer": {
@@ -91,7 +90,7 @@
             "lowercase"
           ]
         },
-        "author_simple": {
+        "author_folding": {
           "filter": [
             "lowercase",
             "german_normalization"
@@ -131,6 +130,7 @@
         },
         "acm_class": {
           "type": "keyword",
+          "normalizer": "simple",
           "copy_to": ["combined"]
         },
         "authors": {
@@ -162,7 +162,7 @@
             },
             "initials": {
               "type": "keyword",
-              "normalizer": "author_simple",
+              "normalizer": "author_folding",
               "fields": {
                 "folded": {
                   "type": "keyword",
@@ -357,6 +357,7 @@
         },
         "msc_class": {
           "type": "keyword",
+          "normalizer": "simple",
           "copy_to": ["combined"]
         },
         "paper_id": {
@@ -468,7 +469,8 @@
             },
             "name": {
               "type": "text",
-              "analyzer": "folding"
+              "analyzer": "folding",
+              "copy_to": ["combined", "authors_combined"]
             },
             "submitter_id": {
               "type": "integer"
@@ -477,10 +479,12 @@
               "type": "boolean"
             },
             "author_id": {
-              "type": "keyword"
+              "type": "keyword",
+              "copy_to": ["combined"]
             },
             "orcid": {
-              "type": "keyword"
+              "type": "keyword",
+              "copy_to": ["combined"]
             }
           }
         },

--- a/mappings/DocumentMapping.json
+++ b/mappings/DocumentMapping.json
@@ -11,7 +11,25 @@
           "min": 2
         }
       },
+      "char_filter": {
+        "strip_dots_commas": {
+          "type": "mapping",
+          "mappings": [
+            ". => ",
+            ", => "
+          ]
+        }
+      },
       "analyzer": {
+        "combined": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "english_stop",
+            "german_normalization"
+          ]
+        },
         "simple": {
           "type": "custom",
           "tokenizer": "standard",
@@ -31,7 +49,7 @@
         },
         "author_simple": {
           "type": "custom",
-          "tokenizer": "standard",
+          "tokenizer": "whitespace",
           "filter": [
             "lowercase",
             "german_normalization"
@@ -39,7 +57,10 @@
         },
         "author_folding": {
           "type": "custom",
-          "tokenizer": "standard",
+          "tokenizer": "whitespace",
+          "char_filter": [
+            "strip_dots_commas"
+          ],
           "filter": [
             "icu_folding",
             "lowercase",
@@ -96,20 +117,7 @@
         "abstract": {
           "type": "text",
           "analyzer": "standard",
-          "fields": {
-            "english": {
-              "type": "text",
-              "analyzer": "english"
-            },
-            "tex": {
-              "type": "text",
-              "analyzer": "tex_analyzer"
-            }
-          }
-        },
-        "abstract_utf8": {
-          "type": "text",
-          "analyzer": "standard",
+          "copy_to": ["combined"],
           "fields": {
             "english": {
               "type": "text",
@@ -122,7 +130,8 @@
           }
         },
         "acm_class": {
-          "type": "keyword"
+          "type": "keyword",
+          "copy_to": ["combined"]
         },
         "authors": {
           "type": "nested",
@@ -131,6 +140,7 @@
               "type": "text",
               "analyzer": "author_folding",
               "similarity": "classic",
+              "copy_to": ["combined"],
               "fields": {
                 "exact": {
                     "type": "keyword",
@@ -139,8 +149,10 @@
               }
             },
             "last_name": {
-              "type": "keyword",
-              "normalizer": "author_simple",
+              "type": "text",
+              "analyzer": "author_folding",
+              "similarity": "classic",
+              "copy_to": ["combined"],
               "fields": {
                 "folded": {
                   "type": "keyword",
@@ -184,15 +196,18 @@
               "type": "keyword"
             },
             "author_id": {
+              "copy_to": ["combined"],
               "type": "keyword"
             },
             "orcid": {
+              "copy_to": ["combined"],
               "type": "keyword"
             },
             "affiliation": {
               "type": "text",
               "analyzer": "author_folding",
               "similarity": "classic",
+              "copy_to": ["combined"],
               "fields": {
                 "exact": {
                     "type": "keyword",
@@ -206,8 +221,10 @@
           "type": "nested",
           "properties": {
             "first_name": {
-              "type": "keyword",
-              "normalizer": "simple",
+              "type": "text",
+              "analyzer": "author_folding",
+              "similarity": "classic",
+              "copy_to": ["combined"],
               "fields": {
                 "folded": {
                   "type": "keyword",
@@ -216,8 +233,10 @@
               }
             },
             "last_name": {
-              "type": "keyword",
-              "normalizer": "simple",
+              "type": "text",
+              "analyzer": "author_folding",
+              "similarity": "classic",
+              "copy_to": ["combined"],
               "fields": {
                 "folded": {
                   "type": "keyword",
@@ -227,24 +246,35 @@
             },
             "full_name": {
               "type": "text",
-              "analyzer": "folding"
+              "analyzer": "author_folding",
+              "similarity": "classic",
+              "copy_to": ["combined"]
+            },
+            "full_name_initialized": {
+              "type": "text",
+              "analyzer": "author_folding",
+              "similarity": "classic"
             },
             "suffix": {
               "type": "keyword"
             },
             "author_id": {
+              "copy_to": ["combined"],
               "type": "keyword"
             },
             "orcid": {
+              "copy_to": ["combined"],
               "type": "keyword"
             },
             "affiliation": {
+              "copy_to": ["combined"],
               "type": "text"
             }
           }
         },
         "comments": {
           "type": "text",
+          "copy_to": ["combined"],
           "analyzer": "simple",
           "search_analyzer": "standard",
           "search_quote_analyzer": "simple"
@@ -278,7 +308,8 @@
           "format": "year_month"
         },
         "doi": {
-          "type": "keyword"
+          "type": "keyword",
+          "copy_to": ["combined"]
         },
         "formats": {
           "type": "keyword"
@@ -300,11 +331,13 @@
         },
         "journal_ref": {
           "type": "text",
+          "copy_to": ["combined"],
           "analyzer": "simple"
         },
         "report_num": {
           "type": "text",
-          "analyzer": "simple"
+          "analyzer": "simple",
+          "copy_to": ["combined"]
         },
         "license": {
           "properties": {
@@ -320,7 +353,8 @@
           "type": "keyword"
         },
         "msc_class": {
-          "type": "keyword"
+          "type": "keyword",
+          "copy_to": ["combined"]
         },
         "paper_id": {
           "type": "keyword"
@@ -449,12 +483,11 @@
           "analyzer": "standard",
           "search_analyzer": "standard",
           "search_quote_analyzer": "simple",
+          "copy_to": ["combined"],
           "fields": {
             "english": {
               "type": "text",
-              "analyzer": "english",
-              "search_analyzer": "english",
-              "search_quote_analyzer": "simple"
+              "analyzer": "english"
             },
             "tex": {
               "type": "text",
@@ -468,30 +501,15 @@
             }
           }
         },
-        "title_utf8": {
-          "type": "text",
-          "analyzer": "standard",
-          "search_analyzer": "standard",
-          "search_quote_analyzer": "simple",
-          "fields": {
-            "english": {
-              "type": "text",
-              "analyzer": "english"
-            },
-            "tex": {
-              "type": "text",
-              "analyzer": "tex_analyzer"
-            },
-            "keyword": {
-              "type": "keyword"
-            }
-          }
-        },
         "version": {
           "type": "integer"
         },
         "fulltext": {
           "type": "text"
+        },
+        "combined": {
+          "type": "text",
+          "analyzer": "combined"
         }
       }
     }

--- a/mappings/DocumentMapping.json
+++ b/mappings/DocumentMapping.json
@@ -16,7 +16,8 @@
           "type": "mapping",
           "mappings": [
             ". => ",
-            ", => "
+            ", => ",
+            "; => "
           ]
         }
       },
@@ -24,6 +25,9 @@
         "combined": {
           "type": "custom",
           "tokenizer": "whitespace",
+          "char_filter": [
+            "strip_dots_commas"
+          ],
           "filter": [
             "icu_folding",
             "lowercase",

--- a/mappings/DocumentMapping.json
+++ b/mappings/DocumentMapping.json
@@ -357,7 +357,8 @@
           "copy_to": ["combined"]
         },
         "paper_id": {
-          "type": "keyword"
+          "type": "keyword",
+          "copy_to": ["combined"]
         },
         "paper_id_v": {
           "type": "keyword"
@@ -391,10 +392,12 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "keyword"
+                  "type": "keyword",
+                  "copy_to": ["combined"]
                 },
                 "name": {
-                  "type": "keyword"
+                  "type": "keyword",
+                  "copy_to": ["combined"]
                 }
               }
             }

--- a/search/controllers/advanced/__init__.py
+++ b/search/controllers/advanced/__init__.py
@@ -8,12 +8,13 @@ parameters, and produce informative error messages for the user.
 """
 
 from typing import Tuple, Dict, Any, Optional
-
+import re
 from datetime import date, timedelta, datetime
 from dateutil.relativedelta import relativedelta
 from pytz import timezone
 
-from werkzeug.datastructures import MultiDict
+
+from werkzeug.datastructures import MultiDict, ImmutableMultiDict
 from werkzeug.exceptions import InternalServerError, BadRequest, NotFound
 from flask import url_for
 
@@ -23,7 +24,7 @@ from search.services import index, fulltext, metadata
 from search.domain import AdvancedQuery, FieldedSearchTerm, DateRange, \
     Classification, FieldedSearchList, ClassificationList, Query, asdict
 from arxiv.base import logging
-from search.controllers.util import paginate
+from search.controllers.util import paginate, catch_underscore_syntax
 
 from . import forms
 
@@ -60,10 +61,36 @@ def search(request_params: MultiDict) -> Response:
         Raised when there is an unrecoverable error while interacting with the
         search index.
     """
+    # We may need to intervene on the request parameters, so we'll
+    # reinstantiate as a mutable MultiDict.
+    if isinstance(request_params, ImmutableMultiDict):
+        request_params = MultiDict(request_params.items(multi=True))
+
     logger.debug('search request from advanced form')
     response_data: Dict[str, Any] = {}
     response_data['show_form'] = ('advanced' not in request_params)
     logger.debug('show_form: %s', str(response_data['show_form']))
+
+    # Here we intervene on the user's query to look for holdouts from
+    # the classic search system's author indexing syntax (surname_f). We
+    # rewrite with a comma, and show a warning to the user about the
+    # change.
+    has_classic = False
+    for key in request_params.keys():
+        if key.startswith('terms-') and key.endswith('-term'):
+            value = request_params.get(key)
+            i = re.search('terms-([0-9])+-term', key).group(1)
+            field = request_params.get(f'terms-{i}-field')
+            # We are only looking for this syntax in the author search, or
+            # in an all-fields search.
+            if field not in ['all', 'author']:
+                continue
+
+            value, _has_classic = catch_underscore_syntax(value)
+            has_classic = _has_classic if not has_classic else has_classic
+            request_params.setlist(key, [value])
+
+    response_data['has_classic_format'] = has_classic
     form = forms.AdvancedSearchForm(request_params)
 
     q: Optional[Query]
@@ -71,12 +98,14 @@ def search(request_params: MultiDict) -> Response:
     #  If a query was actually submitted via the form, 'advanced' will be
     #  present in the request parameters.
     if 'advanced' in request_params:
+
         if form.validate():
             logger.debug('form is valid')
             q = _query_from_form(form)
 
             # Pagination is handled outside of the form.
             q = paginate(q, request_params)
+
             try:
                 # Execute the search. We'll use the results directly in
                 #  template rendering, so they get added directly to the
@@ -184,7 +213,7 @@ def _update_query_with_classification(q: AdvancedQuery, data: MultiDict) \
 def _update_query_with_terms(q: AdvancedQuery, terms_data: list) \
         -> AdvancedQuery:
     q.terms = FieldedSearchList([
-        FieldedSearchTerm(**term) for term in terms_data if term['term']
+        FieldedSearchTerm(**term) for term in terms_data if term['term']    # type: ignore
     ])
     return q
 

--- a/search/controllers/advanced/forms.py
+++ b/search/controllers/advanced/forms.py
@@ -77,18 +77,34 @@ class ClassificationForm(Form):
 
     # pylint: disable=too-few-public-methods
 
-    computer_science = BooleanField('Computer Science (cs)')
-    economics = BooleanField('Economics (econ)')
-    eess = BooleanField('Electrical Engineering and Systems Science (eess)')
-    mathematics = BooleanField('Mathematics (math)')
-    physics = BooleanField('Physics')
-    physics_archives = SelectField(choices=[
+    # Map arXiv archives to fields on this form. Ideally we would autogenerate
+    # form fields based on the arXiv taxonomy, but this can't easily happen
+    # until we replace the classic-style advanced interface with faceted
+    # search.
+    ARCHIVES = [
+        ('cs', 'computer_science'),
+        ('econ', 'economics'),
+        ('eess', 'eess'),
+        ('math', 'mathematics'),
+        ('physics', 'physics'),
+        ('q-bio', 'q_biology'),
+        ('q-fin', 'q_finance'),
+        ('stat', 'statistics')
+    ]
+    PHYSICS_ARCHIVES = [
         ('all', 'all'), ('astro-ph', 'astro-ph'), ('cond-mat', 'cond-mat'),
         ('gr-qc', 'gr-qc'), ('hep-ex', 'hep-ex'), ('hep-lat', 'hep-lat'),
         ('hep-ph', 'hep-ph'), ('hep-th', 'hep-th'), ('math-ph', 'math-ph'),
         ('nlin', 'nlin'), ('nucl-ex', 'nucl-ex'), ('nucl-th', 'nucl-th'),
         ('physics', 'physics'), ('quant-ph', 'quant-ph')
-    ], default='all')
+    ]
+
+    computer_science = BooleanField('Computer Science (cs)')
+    economics = BooleanField('Economics (econ)')
+    eess = BooleanField('Electrical Engineering and Systems Science (eess)')
+    mathematics = BooleanField('Mathematics (math)')
+    physics = BooleanField('Physics')
+    physics_archives = SelectField(choices=PHYSICS_ARCHIVES, default='all')
     q_biology = BooleanField('Quantitative Biology (q-bio)')
     q_finance = BooleanField('Quantitative Finance (q-fin)')
     statistics = BooleanField('Statistics (stat)')

--- a/search/controllers/advanced/tests.py
+++ b/search/controllers/advanced/tests.py
@@ -521,3 +521,97 @@ class TestPaginationParametersAreFunky(TestCase):
         })
         with self.assertRaises(BadRequest):
             advanced.search(request_data)
+
+
+class TestClassicAuthorSyntaxIsIntercepted(TestCase):
+    """
+    The user may have entered an author query using `surname_f` syntax.
+
+    This is an artefact of the classic search system, and not intended to be
+    supported. Nevertheless, users have become accustomed to this syntax. We
+    therefore rewrite the query using a comma, and show the user a warning
+    about the syntax change.
+    """
+
+    @mock.patch('search.controllers.advanced.index')
+    def test_all_fields_search_contains_classic_syntax(self, mock_index):
+        """User has entered a `surname_f` query in an all-fields term."""
+        request_data = MultiDict({
+            'advanced': True,
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'all',
+            'terms-0-term': 'franklin_r',
+            'size': 50,
+            'order': ''
+        })
+        mock_index.search.return_value = DocumentSet(metadata={}, results=[])
+
+        data, code, headers = advanced.search(request_data)
+        self.assertEqual(data['query'].terms[0].term, "franklin, r",
+                         "The query should be rewritten.")
+        self.assertTrue(data['has_classic_format'],
+                        "A flag denoting the syntax interception should be set"
+                        " in the response context, so that a message may be"
+                        " rendered in the template.")
+
+    @mock.patch('search.controllers.advanced.index')
+    def test_author_search_contains_classic_syntax(self, mock_index):
+        """User has entered a `surname_f` query in an author search."""
+        request_data = MultiDict({
+            'advanced': True,
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'author',
+            'terms-0-term': 'franklin_r',
+            'size': 50,
+            'order': ''
+        })
+        mock_index.search.return_value = DocumentSet(metadata={}, results=[])
+
+        data, code, headers = advanced.search(request_data)
+        self.assertEqual(data['query'].terms[0].term, "franklin, r",
+                         "The query should be rewritten.")
+        self.assertTrue(data['has_classic_format'],
+                        "A flag denoting the syntax interception should be set"
+                        " in the response context, so that a message may be"
+                        " rendered in the template.")
+
+    @mock.patch('search.controllers.advanced.index')
+    def test_all_fields_search_multiple_classic_syntax(self, mock_index):
+        """User has entered a classic query with multiple authors."""
+        request_data = MultiDict({
+            'advanced': True,
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'all',
+            'terms-0-term': 'j franklin_r hawking_s',
+            'size': 50,
+            'order': ''
+        })
+        mock_index.search.return_value = DocumentSet(metadata={}, results=[])
+
+        data, code, headers = advanced.search(request_data)
+        self.assertEqual(data['query'].terms[0].term,
+                         "j franklin, r; hawking, s",
+                         "The query should be rewritten.")
+        self.assertTrue(data['has_classic_format'],
+                        "A flag denoting the syntax interception should be set"
+                        " in the response context, so that a message may be"
+                        " rendered in the template.")
+
+    @mock.patch('search.controllers.advanced.index')
+    def test_title_search_contains_classic_syntax(self, mock_index):
+        """User has entered a `surname_f` query in a title search."""
+        request_data = MultiDict({
+            'advanced': True,
+            'terms-0-operator': 'AND',
+            'terms-0-field': 'title',
+            'terms-0-term': 'franklin_r',
+            'size': 50,
+            'order': ''
+        })
+        mock_index.search.return_value = DocumentSet(metadata={}, results=[])
+
+        data, code, headers = advanced.search(request_data)
+        self.assertEqual(data['query'].terms[0].term, "franklin_r",
+                         "The query should not be rewritten.")
+        self.assertFalse(data['has_classic_format'],
+                         "Flag should not be set, as no rewrite has occurred.")

--- a/search/controllers/simple/tests.py
+++ b/search/controllers/simple/tests.py
@@ -325,3 +325,88 @@ class TestPaginationParametersAreFunky(TestCase):
         })
         with self.assertRaises(BadRequest):
             simple.search(request_data)
+
+
+class TestClassicAuthorSyntaxIsIntercepted(TestCase):
+    """
+    The user may have entered an author query using `surname_f` syntax.
+
+    This is an artefact of the classic search system, and not intended to be
+    supported. Nevertheless, users have become accustomed to this syntax. We
+    therefore rewrite the query using a comma, and show the user a warning
+    about the syntax change.
+    """
+
+    @mock.patch('search.controllers.simple.index')
+    def test_all_fields_search_contains_classic_syntax(self, mock_index):
+        """User has entered a `surname_f` query in an all-fields search."""
+        request_data = MultiDict({
+            'searchtype': 'all',
+            'query': 'franklin_r',
+            'size': 50,
+            'order': ''
+        })
+        mock_index.search.return_value = DocumentSet(metadata={}, results=[])
+
+        data, code, headers = simple.search(request_data)
+        self.assertEqual(data['query'].value, "franklin, r",
+                         "The query should be rewritten.")
+        self.assertTrue(data['has_classic_format'],
+                        "A flag denoting the syntax interception should be set"
+                        " in the response context, so that a message may be"
+                        " rendered in the template.")
+
+    @mock.patch('search.controllers.simple.index')
+    def test_author_search_contains_classic_syntax(self, mock_index):
+        """User has entered a `surname_f` query in an author search."""
+        request_data = MultiDict({
+            'searchtype': 'author',
+            'query': 'franklin_r',
+            'size': 50,
+            'order': ''
+        })
+        mock_index.search.return_value = DocumentSet(metadata={}, results=[])
+
+        data, code, headers = simple.search(request_data)
+        self.assertEqual(data['query'].value, "franklin, r",
+                         "The query should be rewritten.")
+        self.assertTrue(data['has_classic_format'],
+                        "A flag denoting the syntax interception should be set"
+                        " in the response context, so that a message may be"
+                        " rendered in the template.")
+
+    @mock.patch('search.controllers.simple.index')
+    def test_all_fields_search_multiple_classic_syntax(self, mock_index):
+        """User has entered a classic query with multiple authors."""
+        request_data = MultiDict({
+            'searchtype': 'all',
+            'query': 'j franklin_r hawking_s',
+            'size': 50,
+            'order': ''
+        })
+        mock_index.search.return_value = DocumentSet(metadata={}, results=[])
+
+        data, code, headers = simple.search(request_data)
+        self.assertEqual(data['query'].value, "j franklin, r; hawking, s",
+                         "The query should be rewritten.")
+        self.assertTrue(data['has_classic_format'],
+                        "A flag denoting the syntax interception should be set"
+                        " in the response context, so that a message may be"
+                        " rendered in the template.")
+
+    @mock.patch('search.controllers.simple.index')
+    def test_title_search_contains_classic_syntax(self, mock_index):
+        """User has entered a `surname_f` query in a title search."""
+        request_data = MultiDict({
+            'searchtype': 'title',
+            'query': 'franklin_r',
+            'size': 50,
+            'order': ''
+        })
+        mock_index.search.return_value = DocumentSet(metadata={}, results=[])
+
+        data, code, headers = simple.search(request_data)
+        self.assertEqual(data['query'].value, "franklin_r",
+                         "The query should not be rewritten.")
+        self.assertFalse(data['has_classic_format'],
+                         "Flag should not be set, as no rewrite has occurred.")

--- a/search/controllers/util.py
+++ b/search/controllers/util.py
@@ -1,7 +1,15 @@
 """Controller helpers."""
 
+import re
+from typing import Tuple
+
 from wtforms import Form, StringField, validators
+
 from search.domain import Query
+
+CLASSIC_AUTHOR = r"([A-Za-z]+)_([a-zA-Z])(?=$|\s)"
+
+# TODO: these should all be snake-case, or all camel-case, but not both.
 
 
 def doesNotStartWithWildcard(form: Form, field: StringField) -> None:
@@ -35,3 +43,11 @@ def paginate(query: Query, data: dict) -> Query:
     query.page_start = int(data.get('start', 0))
     query.page_size = int(data.get('size', 50))
     return query
+
+
+def catch_underscore_syntax(term: str) -> Tuple[str, bool]:
+    """Rewrite author name strings in `surname_f` format to use commas."""
+    match = re.search(CLASSIC_AUTHOR, term)
+    if not match:
+        return term, False
+    return re.sub(CLASSIC_AUTHOR, "\g<1>, \g<2>;", term).rstrip(';'), True

--- a/search/domain/advanced.py
+++ b/search/domain/advanced.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass, field
 from typing import NamedTuple, Optional
 
 
-class FieldedSearchTerm(NamedTuple):
+@dataclass
+class FieldedSearchTerm:
     """Represents a fielded search term."""
 
     operator: str

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -178,7 +178,6 @@ class Document:
     paper_id_v: str = field(default_factory=str)
     title: str = field(default_factory=str)
     title_tex: str = field(default_factory=str)
-    title_utf8: str = field(default_factory=str)
     source: Dict[str, Any] = field(default_factory=dict)
     version: int = 1
     latest: str = field(default_factory=str)

--- a/search/process/tests.py
+++ b/search/process/tests.py
@@ -38,9 +38,9 @@ class TestTransformMetdata(TestCase):
             ]
         })
         doc = transform.to_search_document(meta)
-        self.assertEqual(doc.authors[0]['first_name'], 'B Ivan')
+        self.assertEqual(doc.authors[0]['first_name'], 'B. Ivan')
         self.assertEqual(doc.authors[0]['last_name'], 'Dole')
-        self.assertEqual(doc.authors[0]['full_name'], 'B Ivan Dole',
+        self.assertEqual(doc.authors[0]['full_name'], 'B. Ivan Dole',
                          "full_name should be generated from first_name and"
                          " last_name")
         self.assertEqual(doc.authors[0]['initials'], ["B", "I"],
@@ -67,9 +67,9 @@ class TestTransformMetdata(TestCase):
             ]
         })
         doc = transform.to_search_document(meta)
-        self.assertEqual(doc.owners[0]['first_name'], 'B Ivan')
+        self.assertEqual(doc.owners[0]['first_name'], 'B. Ivan')
         self.assertEqual(doc.owners[0]['last_name'], 'Dole')
-        self.assertEqual(doc.owners[0]['full_name'], 'B Ivan Dole',
+        self.assertEqual(doc.owners[0]['full_name'], 'B. Ivan Dole',
                          "full_name should be generated from first_name and"
                          " last_name")
         self.assertEqual(doc.owners[0]['initials'], ["B", "I"],
@@ -216,22 +216,22 @@ class TestTransformMetdata(TestCase):
                          meta.secondary_classification)
 
     def test_title(self):
-        """Field ``title`` is populated from ``title``."""
+        """Field ``title`` is populated from ``title_utf8``."""
         meta = DocMeta(**{
             'paper_id': '1234.56789',
-            'title': 'foo title'
+            'title_utf8': 'foo title'
         })
         doc = transform.to_search_document(meta)
         self.assertEqual(doc.title, 'foo title')
 
     def test_title_utf8(self):
-        """Field ``title_utf8`` is populated from ``title_utf8``."""
+        """Field ``title`` is populated from ``title_utf8``."""
         meta = DocMeta(**{
             'paper_id': '1234.56789',
             'title_utf8': 'foö title'
         })
         doc = transform.to_search_document(meta)
-        self.assertEqual(doc.title_utf8, 'foö title')
+        self.assertEqual(doc.title, 'foö title')
 
     def test_source(self):
         """Field ``source`` is populated from ``source``."""

--- a/search/process/transform.py
+++ b/search/process/transform.py
@@ -43,9 +43,6 @@ def _constructACMClass(meta: DocMeta) -> Optional[list]:
 
 
 def _transformAuthor(author: dict) -> dict:
-    # TODO: we should not be stripping punctuation from the name here.
-    # This should be handled by the analyzer. This is related to ARXIVNG-543.
-    author['first_name'] = _strip_punctuation(author['first_name']).strip()
     author['full_name'] = re.sub(r'\s+', ' ', f"{author['first_name']} {author['last_name']}")
     author['initials'] = [pt[0] for pt in author['first_name'].split() if pt]
     # initials = ' '.join(author["initials"])
@@ -102,8 +99,7 @@ _transformations: List[Tuple[str, TransformType, bool]] = [
     ("paper_id_v", _constructPaperVersion, True),
     ("primary_classification", "primary_classification", True),
     ("secondary_classification", "secondary_classification", True),
-    ("title", "title", True),
-    ("title_utf8", "title_utf8", True),
+    ("title", "title_utf8", True),
     # ("title_tex", "title", True),
     ("source", "source", True),
     ("version", "version", True),

--- a/search/routes/ui.py
+++ b/search/routes/ui.py
@@ -56,6 +56,23 @@ def advanced_search() -> Union[str, Response]:
     )
 
 
+@blueprint.route('<string:groups_or_archives>', methods=['GET'])
+def group_search(groups_or_archives: str) -> Union[str, Response]:
+    """
+    Short-cut for advanced search with group or archive pre-selected.
+
+    Note that this only supports options supported in the advanced search
+    interface. Anything else will result in a 404.
+    """
+    print(groups_or_archives)
+    response, code, _ = advanced.group_search(request.args, groups_or_archives)
+    return render_template(
+        "search/advanced_search.html",
+        pagetitle="Advanced Search",
+        **response
+    )
+
+
 @blueprint.route('status', methods=['GET', 'HEAD'])
 def service_status() -> Union[str, Response]:
     """

--- a/search/routes/ui.py
+++ b/search/routes/ui.py
@@ -130,9 +130,10 @@ def url_for_author_search_builder() -> Dict[str, Callable]:
     """Inject a function to build author name query URLs."""
     def url_for_author_search(forename: str, surname: str) -> str:
         parts = url_parse(url_for('ui.search'))
+        forename_part = ' '.join([part[0] for part in forename.split()])
         parts = parts.replace(query=url_encode({
             'searchtype': 'author',
-            'query': f'"{surname}, {forename}"'
+            'query': f'{surname}, {forename_part}'
         }))
         url: str = url_unparse(parts)
         return url

--- a/search/routes/ui.py
+++ b/search/routes/ui.py
@@ -131,9 +131,10 @@ def url_for_author_search_builder() -> Dict[str, Callable]:
     def url_for_author_search(forename: str, surname: str) -> str:
         parts = url_parse(url_for('ui.search'))
         forename_part = ' '.join([part[0] for part in forename.split()])
+        name = f'{surname}, {forename_part}' if forename_part else surname
         parts = parts.replace(query=url_encode({
             'searchtype': 'author',
-            'query': f'{surname}, {forename_part}'
+            'query': name
         }))
         url: str = url_unparse(parts)
         return url

--- a/search/services/index/__init__.py
+++ b/search/services/index/__init__.py
@@ -316,8 +316,7 @@ class SearchSession(object):
             elif isinstance(query, SimpleQuery):
                 current_search = prepare.simple(current_search, query)
         except TypeError as e:
-            logger.error('Malformed query')
-            print(e)
+            logger.error('Malformed query: %s', str(e))
             raise QueryError('Malformed query') from e
 
         # Highlighting is performed by Elasticsearch; here we include the

--- a/search/services/index/__init__.py
+++ b/search/services/index/__init__.py
@@ -38,8 +38,10 @@ from search.domain import Document, DocumentSet, Query, AdvancedQuery, \
 from .exceptions import QueryError, IndexConnectionError, DocumentNotFound, \
     IndexingError, OutsideAllowedRange, MappingError
 from .util import MAX_RESULTS
-
-from . import prepare, results
+from .advanced import advanced_search
+from .simple import simple_search
+from .highlighting import highlight
+from . import results
 
 logger = logging.getLogger(__name__)
 
@@ -312,16 +314,16 @@ class SearchSession(object):
         current_search = self._base_search()
         try:
             if isinstance(query, AdvancedQuery):
-                current_search = prepare.advanced(current_search, query)
+                current_search = advanced_search(current_search, query)
             elif isinstance(query, SimpleQuery):
-                current_search = prepare.simple(current_search, query)
+                current_search = simple_search(current_search, query)
         except TypeError as e:
             logger.error('Malformed query: %s', str(e))
             raise QueryError('Malformed query') from e
 
         # Highlighting is performed by Elasticsearch; here we include the
         # fields and configuration for highlighting.
-        current_search = prepare.highlight(current_search)
+        current_search = highlight(current_search)
 
         with handle_es_exceptions():
             # Slicing the search adds pagination parameters to the request.

--- a/search/services/index/__init__.py
+++ b/search/services/index/__init__.py
@@ -317,6 +317,7 @@ class SearchSession(object):
                 current_search = prepare.simple(current_search, query)
         except TypeError as e:
             logger.error('Malformed query')
+            print(e)
             raise QueryError('Malformed query') from e
 
         # Highlighting is performed by Elasticsearch; here we include the

--- a/search/services/index/advanced.py
+++ b/search/services/index/advanced.py
@@ -1,0 +1,143 @@
+"""Supports the advanced search feature."""
+
+from typing import Any
+
+from elasticsearch_dsl import Search, Q, SF
+from elasticsearch_dsl.query import Range, Match, Bool
+
+from search.domain import AdvancedQuery, Classification
+
+from .prepare import SEARCH_FIELDS
+from .util import sort
+
+
+def advanced_search(search: Search, query: AdvancedQuery) -> Search:
+    """
+    Prepare a :class:`.Search` from a :class:`.AdvancedQuery`.
+
+    Parameters
+    ----------
+    search : :class:`.Search`
+        An Elasticsearch search in preparation.
+    query : :class:`.AdvancedQuery`
+        An advanced query, originating from the advanced search controller.
+
+    Returns
+    -------
+    :class:`.Search`
+        The passed ES search object, updated with specific query parameters
+        that implement the advanced query.
+
+    """
+    # Classification and date are treated as filters; this foreshadows the
+    # behavior of faceted search.
+    if not query.include_older_versions:
+        search = search.filter("term", is_current=True)
+    q = (
+        _fielded_terms_to_q(query)
+        & _date_range(query)
+        & _classifications(query)
+    )
+    if query.order is None or query.order == 'relevance':
+        # Boost the current version heavily when sorting by relevance.
+        q = Q('function_score', query=q, boost=5, boost_mode="multiply",
+              score_mode="max",
+              functions=[
+                SF({'weight': 5, 'filter': Q('term', is_current=True)})
+              ])
+    search = sort(query, search)
+    search = search.query(q)
+    return search
+
+
+def _classification(field: str, classification: Classification) -> Match:
+    """Get a query part for a :class:`.Classification`."""
+    query = Q()
+    if classification.group:
+        field_name = '%s__group__id' % field
+        query &= Q('match', **{field_name: classification.group})
+    if classification.archive:
+        field_name = '%s__archive__id' % field
+        query &= Q('match', **{field_name: classification.archive})
+    if classification.category:
+        field_name = '%s__category__id' % field
+        query &= Q('match', **{field_name: classification.category})
+    return query
+
+
+def _classifications(q: AdvancedQuery) -> Match:
+    """Get a query part for classifications on an :class:`.AdvancedQuery`."""
+    if not q.primary_classification:
+        return Q()
+    query = _classification('primary_classification',
+                            q.primary_classification[0])
+    if len(q.primary_classification) > 1:
+        for classification in q.primary_classification[1:]:
+            query |= _classification('primary_classification', classification)
+    return query
+
+
+def _date_range(q: AdvancedQuery) -> Range:
+    """Generate a query part for a date range."""
+    if not q.date_range:
+        return Q()
+    params = {}
+    if q.date_range.start_date:
+        params["gte"] = q.date_range.start_date.strftime('%Y-%m-%dT%H:%M:%S%z')
+    if q.date_range.end_date:
+        params["lt"] = q.date_range.end_date.strftime('%Y-%m-%dT%H:%M:%S%z')
+    return Q('range', submitted_date=params)
+
+
+def _grouped_terms_to_q(term_pair: tuple) -> Q:
+    """Generate a :class:`.Q` from grouped terms."""
+    term_a_raw, operator, term_b_raw = term_pair
+
+    if type(term_a_raw) is tuple:
+        term_a = _grouped_terms_to_q(term_a_raw)
+    else:
+        term_a = SEARCH_FIELDS[term_a_raw.field](term_a_raw.term)
+
+    if type(term_b_raw) is tuple:
+        term_b = _grouped_terms_to_q(term_b_raw)
+    else:
+        term_b = SEARCH_FIELDS[term_b_raw.field](term_b_raw.term)
+
+    if operator == 'OR':
+        return term_a | term_b
+    elif operator == 'AND':
+        return term_a & term_b
+    elif operator == 'NOT':
+        return term_a & ~term_b
+    else:
+        # TODO: Confirm proper exception.
+        raise TypeError("Invalid operator for terms")
+
+
+def _get_operator(obj: Any) -> str:
+    if type(obj) is tuple:
+        return _get_operator(obj[0])
+    return obj.operator     # type: ignore
+
+
+def _group_terms(query: AdvancedQuery) -> tuple:
+    """Group fielded search terms into a set of nested tuples."""
+    terms = query.terms[:]
+    for operator in ['NOT', 'AND', 'OR']:
+        i = 0
+        while i < len(terms) - 1:
+            if _get_operator(terms[i+1]) == operator:
+                terms[i] = (terms[i], operator, terms[i+1])
+                terms.pop(i+1)
+                i -= 1
+            i += 1
+    assert len(terms) == 1
+    return terms[0]     # type: ignore
+
+
+def _fielded_terms_to_q(query: AdvancedQuery) -> Match:
+    if len(query.terms) == 1:
+        return SEARCH_FIELDS[query.terms[0].field](query.terms[0].term)
+    elif len(query.terms) > 1:
+        return _grouped_terms_to_q(_group_terms(query))
+    return Q('match_all')

--- a/search/services/index/authors.py
+++ b/search/services/index/authors.py
@@ -176,16 +176,20 @@ def author_query(term: str, operator: str = 'AND') -> Q:
     return (string_query(term, operator=operator)
             | string_query(term, path="owners", operator=operator)
             | broad_query(remove_single_characters(term), operator=operator)
-            | broad_query(remove_single_characters(term), "owners", operator=operator))
+            | broad_query(remove_single_characters(term), "owners",
+                          operator=operator))
 
 
 def author_id_query(term: str) -> Q:
     """Generate a query part for Author ID using the ES DSL."""
     return (
-        Q("nested", path="authors", query=Q_('match', f'authors__author_id', term))
-        | Q("nested", path="owners", query=Q_('match', f'owners__author_id', term))
+        Q("nested", path="authors", query=Q_('match', f'authors__author_id',
+                                             term))
+        | Q("nested", path="owners", query=Q_('match', f'owners__author_id',
+                                              term))
         | Q_('match', f'submitter__author_id', term)
     )
+
 
 def orcid_query(term: str) -> Q:
     """Generate a query part for ORCID ID using the ES DSL."""

--- a/search/services/index/authors.py
+++ b/search/services/index/authors.py
@@ -85,7 +85,7 @@ def part_query(term: str, path: str = "authors") -> Q:
         # handle wildcards, literals, etc.
         q = Q("query_string",
               fields=AUTHOR_QUERY_FIELDS, default_operator='AND',
-              analyze_wildcard=True, allow_leading_wildcard=False,
+              allow_leading_wildcard=False,
               type="cross_fields", query=escape(term))
 
     return Q("nested", path=path, query=q, score_mode='sum')
@@ -99,9 +99,8 @@ def string_query(term: str, path: str = 'authors', operator: str = 'AND') -> Q:
         f"{path}.full_name_initialized"
     ]
     q = Q("query_string", fields=AUTHOR_QUERY_FIELDS,
-          default_operator=operator, analyze_wildcard=True,
-          allow_leading_wildcard=False, type="cross_fields",
-          query=escape(term))
+          default_operator=operator, allow_leading_wildcard=False,
+          type="cross_fields", query=escape(term))
     return Q('nested', path=path, query=q, score_mode='sum')
 
 
@@ -165,7 +164,7 @@ def author_query(term: str, operator: str = 'AND') -> Q:
     logger.debug(f"General search: {term}")
 
     # All terms must match within the author/owner names as a whole.
-    q = Q('query_string', fields=['authors_combined'], query=term,
+    q = Q('query_string', fields=['authors_combined'], query=escape(term),
           default_operator='and')
     # We include both w/in author and among author matches, so that more
     # precise matches get more weight.

--- a/search/services/index/authors.py
+++ b/search/services/index/authors.py
@@ -18,7 +18,7 @@ logger.propagate = False
 # We don't remove stopwords from author names at index time because
 # institutions and collaborations are often treated as authors just like
 # people.
-STOP = ["and", "or", "the", "of", "a", "for", "an"]
+STOP = ["and", "or", "the", "of", "a", "for"]
 
 
 def _remove_stopwords(term: str) -> str:
@@ -139,6 +139,7 @@ def author_query(term: str, operator: str = 'AND') -> Q:
     """
     logger.debug(f"Author query for {term}")
     term = _remove_stopwords(term.lower())
+    print(term)
     # term = term.lower()
     if ";" in term:     # Authors are individuated.
         logger.debug(f"Authors are individuated: {term}")

--- a/search/services/index/authors.py
+++ b/search/services/index/authors.py
@@ -2,280 +2,195 @@
 
 from typing import Tuple, Optional, List
 import re
-from string import punctuation
+from functools import reduce, wraps
+from operator import ior, iand
+
 from elasticsearch_dsl import Search, Q, SF
-from .util import wildcardEscape, is_literal_query, Q_, escape
 
+from arxiv.base import logging
 
+from .util import wildcardEscape, escape, STRING_LITERAL, \
+    remove_single_characters
+
+logger = logging.getLogger(__name__)
+
+# We don't remove stopwords from author names at index time because
+# institutions and collaborations are often treated as authors just like
+# people.
 STOP = ["and", "or", "the", "of", "a", "for", "an"]
 
 
-# TODO: remove this when we address the author name bug in
-# search.process.transform..
-def _strip_punctuation(s: str) -> str:
-    return ''.join([c for c in s if c not in punctuation])
-
-
-# TODO: revisit author name indexing in document mappings.
-# Ideally stopwords would be removed at index time, but authors are indexed
-# as keywords which makes that difficult.
 def _remove_stopwords(term: str) -> str:
-    """Remove common stopwords that will match on institutions."""
-    _term = str(term)
+    """Remove common stopwords, except in literal queries."""
+    parts = re.split(STRING_LITERAL, term)
     for stopword in STOP:
-        _term =re.sub(f"(^|\s+){stopword}(\s+|$)", " ", _term)
-    return _term
+        parts = [re.sub(f"(^|\s+){stopword}(\s+|$)", " ", part)
+                 if not part.startswith('"') and not part.startswith("'")
+                 else part for part in parts]
+    return "".join(parts)
 
 
-def _parseName(au_safe: str) -> Tuple[str, Optional[str]]:
-    """Parse a name string into its (likely) constituent parts."""
-    # We interpret the comma as separating the surname from the forename.
-    if "," in au_safe:
-        au_parts = au_safe.split(',')
-        if len(au_parts) >= 2:
-            surname = au_parts[0]
-            forename = au_parts[1]
-            return surname.strip(), forename.strip()
-
-    # Otherwise, treat the last word in the name as the surname. This isn't
-    # a great approach from first principles, but it produces reasonable
-    # results in practice.
-    term_parts = au_safe.split()
-    if len(term_parts) > 1:
-        return term_parts[-1], ' '.join(term_parts[:-1])
-    return au_safe, None
+def _has_wildcard(term: str) -> bool:
+    """Determine whether or not ``term`` contains a wildcard."""
+    return (('*' in term or '?' in term) and not
+            (term.startswith('*') or term.startswith('?')))
 
 
-# TODO: once we're happy with the behavior, this can be broken out into smaller
-# pieces, for readability.
-def construct_author_query(term: str) -> Q:
-    """Generate an author name query in the ElasticSearch DSL."""
-    term = escape(term)
-    _author_q = Q()
-    score_functions: List = []
-
-    # Multiple authors can be provided, delimited by commas.
-    for au_name in term.split(';'):
-        au_name = au_name.strip().lower()
-
-        au_name, has_wildcard = wildcardEscape(au_name)
-        au_safe = au_name.replace('*', '').replace('?', '').replace('"', '')
-        surname_safe, forename_safe = _parseName(au_safe)
-
-        if forename_safe is not None:
-            # TODO: remove this when the author name bug is fixed in
-            # search.process.transform. Since we are erroneously removing
-            # punctuation from author names prior to indexing, it's important
-            # to do the same here so that results are returned.
-            forename_safe = _strip_punctuation(forename_safe)
-
-            fullname_safe = f'{forename_safe} {surname_safe}'
-        else:
-            fullname_safe = surname_safe
-        _q = (
-            # Matching on keyword field is effectively an exact match.
-            Q('match', **{
-                'authors__full_name__exact': {
-                    'query': fullname_safe, 'boost': 30
-                },
-            })
-
-            # The next best case is that the query is a substring of
-            #  the full name.
-            | Q('match_phrase', **{
-                'authors__full_name': {'query': fullname_safe, 'boost': 9}
-            })
-        )
-        if not is_literal_query(term):
-            # Search across all authors, and prefer documents for which a
-            # greater number of authors respond. For this part of the search
-            # we want to avoid artificially high scores when only initials
-            # match, so we drop solo characters from the query.
-            term_sans_inits = ' '.join(part for part in
-                                       _remove_stopwords(term).split()
-                                       if len(part) > 1)
-            _q |= Q('multi_match', fields=['authors.full_name'],
-                    query=term_sans_inits, boost=8, type="cross_fields")
-            # We support wildcards (?*) within each author name. Since
-            # ES will treat the non-wildcard part of the term as a literal,
-            # we need to apply each word in the name separately.
-            if has_wildcard:
-                _q_wc = Q()
-                for npart in au_name.split():
-                    _q_wc &= Q('wildcard', **{
-                        'authors__full_name': {
-                            'value': npart, 'boost': 8
-                        }
-                    })
-                _q |= _q_wc
-            # Otherwise, just do a general text match on the full name
-            # as a third-best option. In this case, word order won't
-            # matter, but all words in the name must be present.
-            else:
-                _q |= Q('match', **{
-                    'authors__full_name': {
-                        'query': fullname_safe,
-                        'boost': 8,
-                        'operator': 'and'
-                    }
-                })
-
-        # We want to boost the most relevant results to the top, using
-        # the parsed name parts available in the search index.
-        score_functions += [
-            # Give an extra boost based on how well the query matches
-            # the full name.
-            SF({
-                'weight': 25,
-                'filter': Q(
-                    "nested", path="authors", query=Q(
-                        'match', **{
-                            'authors__full_name': fullname_safe
-                        }
-                    ),
-                    score_mode='sum'
-                )
-            }),
-            SF({
-                'weight': 20,
-                'filter': Q(
-                    "nested", path="authors", query=Q(
-                        'match', **{
-                            'authors__full_name_initialized': au_safe
-                        }
-                    ),
-                    score_mode='sum'
-                )
-            })
-        ]
-
-        if not is_literal_query(au_name):
-            # Give an extra boost if the last word of the query is
-            # in the parsed last name field.
-            score_functions += [
-                SF({
-                    'weight': 15,
-                    'filter': Q(
-                        "nested", path="authors", query=Q(
-                            'match', **{
-                                'authors__last_name': surname_safe
-                            }
-                        ),
-                        score_mode='sum'
-                    )
-                }),
-            ]
-
-        if not is_literal_query(au_name):
-            # If the name has more than one word, it likely contains a forename
-            # or initials.
-            if forename_safe is not None:
-                init_forename = ' '.join(
-                    [part[0] for part in forename_safe.split()]
-                )
-                init_name = ' '.join(init_forename.split() + [surname_safe])
-                _q |= (
-                    Q('match', **{
-                        'authors__full_name_initialized__exact': {
-                            'query': init_name,
-                            'boost': 5
-                        }
-                    })
-                    | Q('match_phrase', **{
-                        'authors__full_name_initialized': {
-                            'query': init_name,
-                            'boost': 4
-                        }
-                    })
-                )
-
-                score_functions += [
-                    SF({
-                        'weight': 12,
-                        'filter': Q(
-                            "nested", path="authors", query=Q(
-                                "match", **{
-                                    "authors__first_name__exact": forename_safe
-                                }
-                            ),
-                            score_mode='sum'
-                        )
-                    }),
-                    SF({
-                        'weight': 8,
-                        'filter': Q(
-                            "nested", path="authors", query=Q(
-                                "match", **{
-                                    "authors__first_name__exact": init_forename
-                                }
-                            ),
-                            score_mode='sum'
-                        )
-                    }),
-                    SF({
-                        'weight': 10, 'filter': Q(
-                            "nested", path="authors", query=Q(
-                                "match_phrase", **{
-                                    "authors__first_name": forename_safe
-                                }
-                            ),
-                            score_mode='sum'
-                        )
-                    }),
-                    SF({
-                        'weight': 8, 'filter': Q(
-                            "nested", path="authors", query=Q(
-                                "match_phrase", **{
-                                    "authors__first_name": init_forename
-                                }
-                            ),
-                            score_mode='sum'
-                        )
-                    }),
-                    SF({
-                        'weight': 1, 'filter': Q(
-                            "nested", path="authors", query=Q(
-                                "match", **{
-                                    "authors__first_name": forename_safe
-                                }
-                            ),
-                            score_mode='sum'
-                        )
-                    }),
-                    SF({
-                        'weight': 1, 'filter': Q(
-                            "nested", path="authors", query=Q(
-                                "match", **{
-                                    "authors__first_name": init_forename
-                                }
-                            ),
-                            score_mode='sum'
-                        )
-                    }),
-                    SF({
-                        'weight': 2, 'filter': Q(
-                            "nested", path="authors", query=Q(
-                                "match", **{
-                                    "authors__initials": init_forename.lower()
-                                }
-                            ),
-                            score_mode='sum'
-                        )
-                    }),
-                ]
-        _author_q &= Q("nested", path="authors", query=_q, score_mode='sum')
-
-    return Q('function_score', query=_author_q,
-             score_mode="sum", boost=1, boost_mode='multiply',
-             functions=score_functions)
+def Q_(qtype: str, field: str, value: str) -> Q:
+    """Generate an appropriate :class:`Q` based on wildcard presence."""
+    if _has_wildcard(value):
+        return Q("wildcard", **{field: {"value": escape(value)}})
+    return Q(qtype, **{field: escape(value)})
 
 
-def construct_author_id_query(field: str, term: str) -> Q:
-    """Generate a query part for ORCID and Author ID using the ES DSL."""
+def part_query(term: str, path: str = "authors") -> Q:
+    """Build a query that matches within a single author/owner."""
+    SURNAME = f"{path}__last_name"
+    FORENAME = f"{path}__first_name"
+    AUTHOR_QUERY_FIELDS = [
+        f"{path}.full_name",
+        f"{path}.last_name",
+        f"{path}.full_name_initialized"
+    ]
+    term = term.strip()
+    logger.debug(f'{path} part_query for {term}')
+
+    # Commas are used to distinguish surname and forename.
+    forename_is_individuated = "," in term
+    if forename_is_individuated:
+        # We treat the entire part as a search for a single author. The part
+        # before the comma is treated as a surname, and the part after the
+        # comma is treated as a forename or a prefix of the forename.
+        name_parts = term.split(",")
+        surname = name_parts[0].strip()
+        forename = " ".join(name_parts[1:]).strip()
+        q_surname = Q_("match", SURNAME, surname)
+        q_forename = Q_("match", FORENAME, forename)
+
+        # It may be the case that the forename consists of initials or some
+        # other prefix/partial forename. For a match of this kind, each part
+        # of the forename part must be a prefix of a term in the forename.
+        q_forename_prefix = Q()
+        for forename_part in forename.split():
+            q_forename_prefix &= Q_("prefix", FORENAME, forename_part)
+        q_forename |= q_forename_prefix
+
+        # We will treat this as a search for a single author; surname and
+        # forename parts must match in the same (nested) author.
+        q = q_surname & q_forename
+    else:
+        # Match across all fields within a single author. We don't know which
+        # bits of the query match which bits of the author name. This will
+        # handle wildcards, literals, etc.
+        q = Q("query_string",
+              fields=AUTHOR_QUERY_FIELDS, default_operator='AND',
+              analyze_wildcard=True, allow_leading_wildcard=False,
+              auto_generate_phrase_queries=True, type="cross_fields",
+              query=escape(term))
+
+    return Q("nested", path=path, query=q, score_mode='sum')
+
+
+def string_query(term: str, path: str = 'authors', operator: str = 'AND') -> Q:
+    """Build a query that handles query strings within a single author."""
+    AUTHOR_QUERY_FIELDS = [
+        f"{path}.full_name",
+        f"{path}.last_name",
+        f"{path}.full_name_initialized"
+    ]
+    q = Q("query_string", fields=AUTHOR_QUERY_FIELDS,
+          default_operator=operator, analyze_wildcard=True,
+          allow_leading_wildcard=False, auto_generate_phrase_queries=True,
+          type="cross_fields", query=escape(term))
+    return Q('nested', path=path, query=q, score_mode='sum')
+
+
+def broad_query(term: str, path: str = 'authors', operator: str = 'AND') -> Q:
+    """Build a query that matches all terms across all authors."""
+    logger.debug(f"{path} general query: {term}, operator={operator}")
+    query_parts = [string_query(part, path, operator) for part in term.split()]
+    op = iand if operator == 'AND' else ior
+    return reduce(op, query_parts)
+
+
+def author_query(term: str, operator: str = 'AND') -> Q:
+    """
+    Construct a query based on author (and owner) names.
+
+    Substrings delimited by semicolons should only match if the terms in that
+    substring match within a single author.
+
+    If a substring (delimited or not) contains a comma, everything before the
+    first comma will be treated as a surname, and the remainder treated as
+    either the forename or initials. In this scenario, all terms must match
+    within a single author.
+
+    Otherwise, we will simply match all of the parts of the query across all
+    of the available author/owner fields. Each part of the query must match in
+    at least one field in at least one author/owner.
+
+    Parameters
+    ----------
+    term: str
+        Raw querystring. Should not be escaped or normalized in any way.
+    operator : str
+        Default: 'AND'; anything else treated as 'OR'. If 'OR', relaxes the
+        requirement that all parts of the query match. This is useful for
+        "all fields" searches, in which only part of the query may be expected
+        to match on an author/owner name.
+
+    Returns
+    -------
+    :class:`.Q`
+        An Elasticsearch DSL query part.
+
+    """
+    logger.debug(f"Author query for {term}")
+    term = _remove_stopwords(term.lower())
+    # term = term.lower()
+    if ";" in term:     # Authors are individuated.
+        logger.debug(f"Authors are individuated: {term}")
+        return reduce(iand if operator == "AND" else ior, [
+            (part_query(author_part) | part_query(author_part, "owners"))
+            for author_part in term.split(";")
+        ])
+
+    if "," in term:     # Forename is individuated.
+        logger.debug(f"Forename is individuated: {term}")
+        return part_query(term) | part_query(term, "owners")
+
+    if '"' in term:     # Probably a literal search.
+        logger.debug(f"Contains literal: {term}")
+
+        # Apply literal parts of the query separately.
+        return reduce(iand if operator == 'AND' else ior, [
+            (string_query(part, operator=operator)
+             | string_query(part, path="owners", operator=operator))
+            for part in re.split(STRING_LITERAL, term) if part
+        ])
+
+    logger.debug(f"General search: {term}")
+    # General author name query; may match on any field. We include both
+    # w/in author and among author matches, so that more precise matches get
+    # more weight.
+    return (string_query(term, operator=operator)
+            | string_query(term, path="owners", operator=operator)
+            | broad_query(remove_single_characters(term), operator=operator)
+            | broad_query(remove_single_characters(term), "owners", operator=operator))
+
+
+def author_id_query(term: str) -> Q:
+    """Generate a query part for Author ID using the ES DSL."""
     return (
-        Q("nested", path="authors",
-          query=Q_('match', f'authors__{field}', term))
-        | Q("nested", path="owners",
-            query=Q_('match', f'owners__{field}', term))
-        | Q_('match', f'submitter__{field}', term)
+        Q("nested", path="authors", query=Q_('match', f'authors__author_id', term))
+        | Q("nested", path="owners", query=Q_('match', f'owners__author_id', term))
+        | Q_('match', f'submitter__author_id', term)
+    )
+
+def orcid_query(term: str) -> Q:
+    """Generate a query part for ORCID ID using the ES DSL."""
+    return (
+        Q("nested", path="authors", query=Q_('match', f'authors__orcid', term))
+        | Q("nested", path="owners", query=Q_('match', f'owners__orcid', term))
+        | Q_('match', f'submitter__orcid', term)
     )

--- a/search/services/index/highlighting.py
+++ b/search/services/index/highlighting.py
@@ -1,0 +1,269 @@
+"""
+Provide hit highlighting to the search.
+
+Highlighting requires amendation of the query as well as post-processing of
+the returned results. :func:`.highlight` adds a highlighting part to the query
+in the Elasticsearch DSL. :func:`.add_highlighting` performs post-processing
+of the search results. :func:`.preview` generates a TeX-safe snippet for
+abridged display in the search results.
+"""
+
+import re
+from typing import Any
+
+from elasticsearch_dsl import Search, Q, SF
+from elasticsearch_dsl.response import Response
+import bleach
+
+from .util import TEXISM
+
+HIGHLIGHT_TAG_OPEN = '<span class="search-hit mathjax">'
+HIGHLIGHT_TAG_CLOSE = '</span>'
+
+
+def highlight(search: Search) -> Search:
+    """
+    Apply hit highlighting to the search, before execution.
+
+    Parameters
+    ----------
+    search : :class:`.Search`
+
+    Returns
+    -------
+    :class:`.Search`
+        The search object that was originally passed, updated to include
+        requests for hit highlighting.
+
+    """
+    # Highlight class .search-hit defined in search.sass
+    search = search.highlight_options(
+        pre_tags=[HIGHLIGHT_TAG_OPEN],
+        post_tags=[HIGHLIGHT_TAG_CLOSE]
+    )
+    search = search.highlight('title', type='plain', number_of_fragments=0)
+    search = search.highlight('title.english', type='plain',
+                              number_of_fragments=0)
+    search = search.highlight('title.tex', type='plain',
+                              number_of_fragments=0)
+
+    search = search.highlight('comments', number_of_fragments=0)
+    # Highlight any field the name of which begins with "author".
+    search = search.highlight('author*')
+    search = search.highlight('journal_ref', type='plain')
+    search = search.highlight('acm_class', number_of_fragments=0)
+    search = search.highlight('msc_class', number_of_fragments=0)
+    search = search.highlight('doi', type='plain')
+    search = search.highlight('report_num', type='plain')
+
+    # Setting number_of_fragments to 0 tells ES to highlight the entire
+    # abstract.
+    search = search.highlight('abstract', type='plain', number_of_fragments=0)
+    search = search.highlight('abstract.tex', type='plain',
+                              number_of_fragments=0)
+    search = search.highlight('abstract.english', type='plain',
+                              number_of_fragments=0)
+    return search
+
+
+def preview(value: str, fragment_size: int = 400,
+            start_tag: str = HIGHLIGHT_TAG_OPEN,
+            end_tag: str = HIGHLIGHT_TAG_CLOSE) -> str:
+    """
+    Generate a snippet preview that doesn't breaking TeXisms or highlighting.
+
+    Parameters
+    ----------
+    value : str
+        The full text of the field, which we assume contains TeXisms and/or
+        hit hightlighting tags.
+    fragment_size : int
+        The desired size of the preview (number of characters). The actual
+        preview may be smaller or larger than this target, depending on where
+        the TeXisms and highlight tags are located.
+    start_tag : str
+        The opening tag used for hit highlighting.
+    end_tag: str
+        The closing tag used for hit highlighting.
+
+    Returns
+    -------
+    str
+        A preview that is approximately ``fragment_size`` long.
+
+    """
+    if start_tag in value and end_tag in value:
+        start = value.index(start_tag)
+        end = value.index(end_tag) + len(end_tag)
+        # Roll back the start until we hit a TeXism or HTML tag, or we get
+        # roughly half the target fragment size.
+        start_frag_size = round((fragment_size - (end - start)) / 2)
+        c = value[start - 1]
+        s = start
+        while start - s < start_frag_size and s > 0:
+            if c in '$>':   # This may or may not be an actual HTML tag or TeX.
+                break       # But it doesn't hurt to play it safe.
+            s -= 1
+            c = value[s - 1]
+        start = s
+        # Move the start forward slightly, to find a word boundary.
+        while c not in '.,!? \t\n$<' and start > 0:
+            start += 1
+            c = value[start - 1]
+    else:
+        # There is no highlighting; we'll start at the beginning, and find
+        # a safe place to end.
+        start = 0
+        end = 1
+
+    # Jump the end forward until we consume (as much as possible of) the
+    # rest of the target fragment size.
+    remaining = max(0, fragment_size - (end - start))
+    end += _end_safely(value[end:], remaining, start_tag=start_tag,
+                       end_tag=end_tag)
+
+    # For paranoia's sake, make sure that no other HTML makes it through.
+    # This will also clean up any unbalanced tags, in case we screwed up
+    # generating the preview.
+    snippet: str = bleach.clean(value[start:end].strip(),
+                                tags=['span'], attributes={'span': 'class'})
+    snippet = (
+        ('&hellip;' if start > 0 else '')
+        + snippet
+        + ('&hellip;' if end < len(value) else '')
+    )
+    return snippet
+
+
+def add_highlighting(result: dict, raw: Response) -> dict:
+    """
+    Add hit highlighting to a search result.
+
+    Parameters
+    ----------
+    result : dict
+        Contains processed search result data destined for the caller.
+    raw : :class:`.Response`
+        A response from Elasticsearch.
+
+    Returns
+    -------
+    dict
+        The ``result`` object, updated with ``highlight`` and ``preview``
+        items.
+
+    """
+    if not hasattr(raw.meta, 'highlight'):
+        return result   # Nothing to do.
+
+    result['highlight'] = {}
+    # The values here will (almost) always be list-like. So we need to stitch
+    # them together.
+    for field in dir(raw.meta.highlight):
+        value = getattr(raw.meta.highlight, field)
+        if hasattr(value, '__iter__'):
+            value = '&hellip;'.join(value)
+
+        # Non-TeX searches may hit inside of TeXisms. Highlighting those
+        # fragments (i.e. inserting HTML) will break MathJax rendering.
+        # To guard against this while preserving highlighting, we move
+        # any highlighting tags from within TeXisms to encapsulate the
+        # entire TeXism.
+        if field in ['title', 'title.english',
+                     'abstract', 'abstract.english']:
+            value = _highlight_whole_texism(value)
+
+        # A hit on authors may originate in several different fields, most
+        # of which are not displayed. And in any case, author names may be
+        # truncated. So instead of highlighting author names themselves, we
+        # set a 'flag' that can get picked up in the template and highlight
+        # the entire author field.
+        if field.startswith('author'):
+            field = 'author'
+            value = True
+        result['highlight'][field] = value
+
+    # If there is a hit in a TeX field, we prefer highlighting on that
+    # field, since other tokenizers will clobber the TeX.
+    for field in ['abstract', 'title']:
+        if f'{field}.tex' in result['highlight']:
+            result['highlight'][field] = \
+                result['highlight'].pop(f'{field}.tex')
+
+    for field in ['abstract.tex', 'abstract.english', 'abstract']:
+        if field in result['highlight']:
+            value = result['highlight'][field]
+            abstract_snippet = preview(value)
+            result['preview']['abstract'] = abstract_snippet
+            result['highlight']['abstract'] = value
+            break
+    for field in ['title.english', 'title']:
+        if field in result['highlight']:
+            result['highlight']['title'] = result['highlight'][field]
+            break
+    return result
+
+
+def _strip_highlight_and_enclose(match: Any) -> str:
+    # typing: ignore
+    value: str = match.group(0)
+    new_value = bleach.clean(value, strip=True, tags=[])
+
+    # If HTML was removed, we will assume that it was highlighting HTML.
+    if len(new_value) < len(value):
+        return f'{HIGHLIGHT_TAG_OPEN}{new_value}{HIGHLIGHT_TAG_CLOSE}'
+    return value
+
+
+def _highlight_whole_texism(value: str) -> str:
+    """Move highlighting from within TeXism to encapsulate whole statement."""
+    return re.sub(TEXISM, _strip_highlight_and_enclose, value)
+
+
+def _start_safely(value: str, start: int, end: int, fragment_size: int,
+                  tolerance: int = 0, start_tag: str = HIGHLIGHT_TAG_OPEN,
+                  end_tag: str = HIGHLIGHT_TAG_CLOSE) -> int:
+    # Try to maximize the length of the fragment up to the fragment_size, but
+    # avoid starting in the middle of a tag or a TeXism.
+    space_remaining = (fragment_size + tolerance) - (end - start)
+
+    remainder = value[start - fragment_size:start]
+    acceptable = value[start - fragment_size - tolerance:start]
+    if end_tag in remainder:
+        # Relative index of the first end tag.
+        first_end_tag = value[start - space_remaining:start].index(end_tag)
+        if start_tag in value[start - space_remaining:first_end_tag]:
+            target_area = value[start - space_remaining:first_end_tag]
+            first_start_tag = target_area.index(start_tag)
+            return (start - space_remaining) + first_start_tag
+    elif '$' in remainder:
+        m = TEXISM.search(acceptable)
+        if m is None:   # Can't get to opening
+            return start - remainder[::-1].index('$') + 1
+        return (start - fragment_size - tolerance) + m.start()
+
+    # Ideally, we hit the fragment size without entering a tag or TeXism.
+    return start - fragment_size
+
+
+def _end_safely(value: str, remaining: int,
+                start_tag: str = HIGHLIGHT_TAG_OPEN,
+                end_tag: str = HIGHLIGHT_TAG_CLOSE) -> int:
+    """Find a fragment end that doesn't break TeXisms or HTML."""
+    # Should match on either a TeXism or a TeXism enclosed in highlight tags.
+    ptn = r'(\$[^\$]+\$)|({}\$[^\$]+\${})'.format(start_tag, end_tag)
+    m = re.search(ptn, value)
+    if m is None:   # Nothing to worry about; the coast is clear.
+        return remaining
+
+    ptn_start = m.start()
+    ptn_end = m.end()
+    if remaining <= ptn_start:  # The ideal end falls before the next TeX/tag.
+        return remaining
+    elif ptn_end < remaining:   # The ideal end falls after the next TeX/tag.
+        return ptn_end + _end_safely(value[ptn_end:], remaining - ptn_end,
+                                     start_tag, end_tag)
+
+    # We can't make it past the end of the next TeX/tag without exceeding the
+    # target fragment size, so we will end at the beginning of the match.
+    return ptn_start

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -123,7 +123,7 @@ def _query_all_fields(term: str) -> Q:
         _query_acm_class(term, operator='or'),
         _query_msc_class(term, operator='or'),
     ]
-    query = match_all_fields & Q("bool", should=queries)
+    query = (match_all_fields | author_query(term)) & Q("bool", should=queries)
     scores = [SF({'weight': i + 1, 'filter': q})
               for i, q in enumerate(queries[::-1])]
     return Q('function_score', query=query, score_mode="sum", functions=scores,

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -173,6 +173,8 @@ def _query_all_fields(term: str) -> Q:
                          query=remove_single_characters(query_term.lower()))
 
     # In addition, all terms must each match in at least one field.
+    # TODO: continue implementing disjunct case, so that partials match on
+    # individual fields (e.g. ORCID, ACM class, etc).
     queries = [
         author_query(term, operator='OR'),
         _query_title(term, default_operator='or'),

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -1,83 +1,27 @@
-"""Functions for preparing a :class:`.Search` (prior to execution)."""
+"""
+Functions for preparing a :class:`.Search` (prior to execution).
 
-from typing import Any, List, Tuple
+The primary public object is ``SEARCH_FIELDS``, which maps :class:`.Query`
+fields to query-building functions in the module.
+"""
+
+from typing import Any, List, Tuple, Callable, Dict
 from functools import reduce, wraps
 from operator import ior
 import re
 from string import punctuation
 
 from elasticsearch_dsl import Search, Q, SF
-from elasticsearch_dsl.query import Range, Match, Bool
 
 from arxiv.base import logging
 
 from search.domain import SimpleQuery, Query, AdvancedQuery, Classification
-from .util import strip_tex, Q_, HIGHLIGHT_TAG_OPEN, HIGHLIGHT_TAG_CLOSE, \
-    is_tex_query, is_literal_query, escape, wildcardEscape, \
-    remove_single_characters
+from .util import strip_tex, Q_, is_tex_query, is_literal_query, escape, \
+    wildcardEscape, remove_single_characters
+from .highlighting import HIGHLIGHT_TAG_OPEN, HIGHLIGHT_TAG_CLOSE
 from .authors import author_query, author_id_query, orcid_query
 
 logger = logging.getLogger(__name__)
-
-
-ALL_SEARCH_FIELDS = ['author', 'title', 'abstract', 'comments', 'journal_ref',
-                     'acm_class', 'msc_class', 'report_num', 'paper_id', 'doi',
-                     'orcid', 'author_id']
-
-TEX_FIELDS = ['title', 'abstract', 'comments']
-
-
-def _get_sort_parameters(query: Query) -> list:
-    if not query.order:
-        return ['_score', '-announced_date_first', '_doc']
-    direction = '-' if query.order.startswith('-') else ''
-    return [query.order, f'{direction}paper_id_v']
-
-
-def _apply_sort(query: Query, search: Search) -> Search:
-    sort_params = _get_sort_parameters(query)
-    if sort_params is not None:
-        search = search.sort(*sort_params)
-    return search
-
-
-def _classification(field: str, classification: Classification) -> Match:
-    """Get a query part for a :class:`.Classification`."""
-    query = Q()
-    if classification.group:
-        field_name = '%s__group__id' % field
-        query &= Q('match', **{field_name: classification.group})
-    if classification.archive:
-        field_name = '%s__archive__id' % field
-        query &= Q('match', **{field_name: classification.archive})
-    if classification.category:
-        field_name = '%s__category__id' % field
-        query &= Q('match', **{field_name: classification.category})
-    return query
-
-
-def _classifications(q: AdvancedQuery) -> Match:
-    """Get a query part for classifications on an :class:`.AdvancedQuery`."""
-    if not q.primary_classification:
-        return Q()
-    query = _classification('primary_classification',
-                            q.primary_classification[0])
-    if len(q.primary_classification) > 1:
-        for classification in q.primary_classification[1:]:
-            query |= _classification('primary_classification', classification)
-    return query
-
-
-def _date_range(q: AdvancedQuery) -> Range:
-    """Generate a query part for a date range."""
-    if not q.date_range:
-        return Q()
-    params = {}
-    if q.date_range.start_date:
-        params["gte"] = q.date_range.start_date.strftime('%Y-%m-%dT%H:%M:%S%z')
-    if q.date_range.end_date:
-        params["lt"] = q.date_range.end_date.strftime('%Y-%m-%dT%H:%M:%S%z')
-    return Q('range', submitted_date=params)
 
 
 def _query_title(term: str, default_operator: str = 'AND') -> Q:
@@ -136,25 +80,6 @@ def _query_paper_id(term: str) -> Q:
             | Q_('match', 'paper_id_v', escape(term)))
 
 
-def _literal_chunks(term: str) -> List[Tuple[str, bool]]:
-    out = []
-    current = ''
-    i = 0
-    while i < len(term):
-        quoted = re.search(r'^"[^"]+"', term[i:])
-        if quoted:
-            out.append((current, False))
-            current = ''
-            out.append((quoted.group(0), True))
-            i += quoted.end()
-        else:
-            current += term[i]
-            i += 1
-    if current:
-        out.append((current, False))
-    return out
-
-
 def _query_all_fields(term: str) -> Q:
     """Construct a query against all fields."""
     # We only perform TeX queries on title and abstract.
@@ -189,11 +114,13 @@ def _query_all_fields(term: str) -> Q:
         _query_msc_class(term),
     ]
     query = match_all_fields & Q("bool", should=queries)
-    scores = [SF({'weight': i + 1, 'filter': q}) for i, q in enumerate(queries[::-1])]
-    return Q('function_score', query=query, score_mode="sum", functions=scores, boost_mode='multiply')
+    scores = [SF({'weight': i + 1, 'filter': q})
+              for i, q in enumerate(queries[::-1])]
+    return Q('function_score', query=query, score_mode="sum", functions=scores,
+             boost_mode='multiply')
 
 
-SEARCH_FIELDS = dict([
+SEARCH_FIELDS: Dict[str, Callable[[str], Q]] = dict([
     ('author', author_query),
     ('title', _query_title),
     ('abstract', _query_abstract),
@@ -208,122 +135,3 @@ SEARCH_FIELDS = dict([
     ('author_id', author_id_query),
     ('all', _query_all_fields)
 ])
-
-
-def _grouped_terms_to_q(term_pair: tuple) -> Q:
-    """Generate a :class:`.Q` from grouped terms."""
-    term_a_raw, operator, term_b_raw = term_pair
-
-    if type(term_a_raw) is tuple:
-        term_a = _grouped_terms_to_q(term_a_raw)
-    else:
-        term_a = SEARCH_FIELDS[term_a_raw.field](term_a_raw.term)
-
-    if type(term_b_raw) is tuple:
-        term_b = _grouped_terms_to_q(term_b_raw)
-    else:
-        term_b = SEARCH_FIELDS[term_b_raw.field](term_b_raw.term)
-
-    if operator == 'OR':
-        return term_a | term_b
-    elif operator == 'AND':
-        return term_a & term_b
-    elif operator == 'NOT':
-        return term_a & ~term_b
-    else:
-        # TODO: Confirm proper exception.
-        raise TypeError("Invalid operator for terms")
-
-
-def _get_operator(obj: Any) -> str:
-    if type(obj) is tuple:
-        return _get_operator(obj[0])
-    return obj.operator     # type: ignore
-
-
-def _group_terms(query: AdvancedQuery) -> tuple:
-    """Group fielded search terms into a set of nested tuples."""
-    terms = query.terms[:]
-    for operator in ['NOT', 'AND', 'OR']:
-        i = 0
-        while i < len(terms) - 1:
-            if _get_operator(terms[i+1]) == operator:
-                terms[i] = (terms[i], operator, terms[i+1])
-                terms.pop(i+1)
-                i -= 1
-            i += 1
-    assert len(terms) == 1
-    return terms[0]     # type: ignore
-
-
-def _fielded_terms_to_q(query: AdvancedQuery) -> Match:
-    if len(query.terms) == 1:
-        term = query.terms[0]
-        return SEARCH_FIELDS[term.field](term.term)
-    elif len(query.terms) > 1:
-        return _grouped_terms_to_q(_group_terms(query))
-    return Q('match_all')
-
-
-def simple(search: Search, query: SimpleQuery) -> Search:
-    """Prepare a :class:`.Search` from a :class:`.SimpleQuery`."""
-    search = search.filter("term", is_current=True)
-    q = SEARCH_FIELDS[query.search_field](query.value)
-    search = search.query(q)
-    search = _apply_sort(query, search)
-    return search
-
-
-def advanced(search: Search, query: AdvancedQuery) -> Search:
-    """Prepare a :class:`.Search` from a :class:`.AdvancedQuery`."""
-    # Classification and date are treated as filters; this foreshadows the
-    # behavior of faceted search.
-    if not query.include_older_versions:
-        search = search.filter("term", is_current=True)
-    q = (
-        _fielded_terms_to_q(query)
-        & _date_range(query)
-        & _classifications(query)
-    )
-    if query.order is None or query.order == 'relevance':
-        # Boost the current version heavily when sorting by relevance.
-        q = Q('function_score', query=q, boost=5, boost_mode="multiply",
-              score_mode="max",
-              functions=[
-                SF({'weight': 5, 'filter': Q('term', is_current=True)})
-              ])
-    search = _apply_sort(query, search)
-    search = search.query(q)
-    return search
-
-
-def highlight(search: Search) -> Search:
-    """Apply hit highlighting to the search, before execution."""
-    # Highlight class .search-hit defined in search.sass
-    search = search.highlight_options(
-        pre_tags=[HIGHLIGHT_TAG_OPEN],
-        post_tags=[HIGHLIGHT_TAG_CLOSE]
-    )
-    # search = search.highlight('title', type='plain', number_of_fragments=0)
-    search = search.highlight('title.english', type='plain', number_of_fragments=0)
-    search = search.highlight('title.tex', type='plain', number_of_fragments=0)
-    # search = search.highlight('title', type='plain',
-    #                           number_of_fragments=0)
-
-    search = search.highlight('comments', number_of_fragments=0)
-    # Highlight any field the name of which begins with "author".
-    search = search.highlight('author*')
-    search = search.highlight('journal_ref', type='plain')
-    search = search.highlight('acm_class', number_of_fragments=0)
-    search = search.highlight('msc_class', number_of_fragments=0)
-    search = search.highlight('doi', type='plain')
-    search = search.highlight('report_num', type='plain')
-
-    # Setting number_of_fragments to 0 tells ES to highlight the entire
-    # abstract.
-    search = search.highlight('abstract', type='plain', number_of_fragments=0)
-    search = search.highlight('abstract.tex', type='plain',
-                              number_of_fragments=0)
-    search = search.highlight('abstract.english', type='plain',
-                               number_of_fragments=0)
-    return search

--- a/search/services/index/results.py
+++ b/search/services/index/results.py
@@ -1,186 +1,22 @@
-"""Functions for processing search results (after execution)."""
+"""
+Functions for processing search results (after execution).
+
+The primary public function in this module is :func:`.to_documentset`.
+"""
 
 import re
 from datetime import datetime
 from math import floor
 from typing import Any, Dict
 
-import bleach
 from elasticsearch_dsl.response import Response
 from search.domain import Document, Query, DocumentSet
 from arxiv.base import logging
 
-from .util import MAX_RESULTS, HIGHLIGHT_TAG_OPEN, HIGHLIGHT_TAG_CLOSE
-
-TEXISM = re.compile(r'(\$[^\$]+\$)')
-
+from .util import MAX_RESULTS, TEXISM
+from .highlighting import add_highlighting, preview
 
 logger = logging.getLogger(__name__)
-
-
-def _strip_highlight_and_enclose(match: Any) -> str:
-    # typing: ignore
-    value: str = match.group(0)
-    new_value = bleach.clean(value, strip=True, tags=[])
-
-    # If HTML was removed, we will assume that it was highlighting HTML.
-    if len(new_value) < len(value):
-        return f'{HIGHLIGHT_TAG_OPEN}{new_value}{HIGHLIGHT_TAG_CLOSE}'
-    return value
-
-
-def _highlight_whole_texism(value: str) -> str:
-    """Move highlighting from within TeXism to encapsulate whole statement."""
-    return re.sub(TEXISM, _strip_highlight_and_enclose, value)
-
-
-def _start_safely(value: str, start: int, end: int, fragment_size: int,
-                  tolerance: int = 0, start_tag: str = HIGHLIGHT_TAG_OPEN,
-                  end_tag: str = HIGHLIGHT_TAG_CLOSE) -> int:
-    # Try to maximize the length of the fragment up to the fragment_size, but
-    # avoid starting in the middle of a tag or a TeXism.
-    space_remaining = (fragment_size + tolerance) - (end - start)
-
-    remainder = value[start - fragment_size:start]
-    acceptable = value[start - fragment_size - tolerance:start]
-    if end_tag in remainder:
-        # Relative index of the first end tag.
-        first_end_tag = value[start - space_remaining:start].index(end_tag)
-        if start_tag in value[start - space_remaining:first_end_tag]:
-            target_area = value[start - space_remaining:first_end_tag]
-            first_start_tag = target_area.index(start_tag)
-            return (start - space_remaining) + first_start_tag
-    elif '$' in remainder:
-        m = TEXISM.search(acceptable)
-        if m is None:   # Can't get to opening
-            return start - remainder[::-1].index('$') + 1
-        return (start - fragment_size - tolerance) + m.start()
-
-    # Ideally, we hit the fragment size without entering a tag or TeXism.
-    return start - fragment_size
-
-
-def _end_safely(value: str, remaining: int,
-                start_tag: str = HIGHLIGHT_TAG_OPEN,
-                end_tag: str = HIGHLIGHT_TAG_CLOSE) -> int:
-    """Find a fragment end that doesn't break TeXisms or HTML."""
-    # Should match on either a TeXism or a TeXism enclosed in highlight tags.
-    ptn = r'(\$[^\$]+\$)|({}\$[^\$]+\${})'.format(start_tag, end_tag)
-    m = re.search(ptn, value)
-    if m is None:   # Nothing to worry about; the coast is clear.
-        return remaining
-
-    ptn_start = m.start()
-    ptn_end = m.end()
-    if remaining <= ptn_start:  # The ideal end falls before the next TeX/tag.
-        return remaining
-    elif ptn_end < remaining:   # The ideal end falls after the next TeX/tag.
-        return ptn_end + _end_safely(value[ptn_end:], remaining - ptn_end,
-                                     start_tag, end_tag)
-
-    # We can't make it past the end of the next TeX/tag without exceeding the
-    # target fragment size, so we will end at the beginning of the match.
-    return ptn_start
-
-
-def _preview(value: str, fragment_size: int = 400,
-             start_tag: str = HIGHLIGHT_TAG_OPEN,
-             end_tag: str = HIGHLIGHT_TAG_CLOSE) -> str:
-    """Generate a snippet preview for highlighted text."""
-    if start_tag in value and end_tag in value:
-        start = value.index(start_tag)
-        end = value.index(end_tag) + len(end_tag)
-        # Roll back the start until we hit a TeXism or HTML tag, or we get
-        # roughly half the target fragment size.
-        start_frag_size = round((fragment_size - (end - start)) / 2)
-        c = value[start - 1]
-        s = start
-        while start - s < start_frag_size and s > 0:
-            if c in '$>':   # This may or may not be an actual HTML tag or TeX.
-                break       # But it doesn't hurt to play it safe.
-            s -= 1
-            c = value[s - 1]
-        start = s
-        # Move the start forward slightly, to find a word boundary.
-        while c not in '.,!? \t\n$<' and start > 0:
-            start += 1
-            c = value[start - 1]
-    else:
-        # There is no highlighting; we'll start at the beginning, and find
-        # a safe place to end.
-        start = 0
-        end = 1
-
-    # Jump the end forward until we consume (as much as possible of) the
-    # rest of the target fragment size.
-    remaining = max(0, fragment_size - (end - start))
-    end += _end_safely(value[end:], remaining, start_tag=start_tag,
-                       end_tag=end_tag)
-
-    # For paranoia's sake, make sure that no other HTML makes it through.
-    # This will also clean up any unbalanced tags, in case we screwed up
-    # generating the preview.
-    snippet: str = bleach.clean(value[start:end].strip(),
-                                tags=['span'], attributes={'span': 'class'})
-    snippet = (
-        ('&hellip;' if start > 0 else '')
-        + snippet
-        + ('&hellip;' if end < len(value) else '')
-    )
-    return snippet
-
-
-def _add_highlighting(result: dict, raw: Response) -> dict:
-    """Add hit highlighting to a search result."""
-    if not hasattr(raw.meta, 'highlight'):
-        return result   # Nothing to do.
-
-    result['highlight'] = {}
-    # The values here will (almost) always be list-like. So we need to stitch
-    # them together.
-    for field in dir(raw.meta.highlight):
-        value = getattr(raw.meta.highlight, field)
-        if hasattr(value, '__iter__'):
-            value = '&hellip;'.join(value)
-
-        # Non-TeX searches may hit inside of TeXisms. Highlighting those
-        # fragments (i.e. inserting HTML) will break MathJax rendering.
-        # To guard against this while preserving highlighting, we move
-        # any highlighting tags from within TeXisms to encapsulate the
-        # entire TeXism.
-        if field in ['title', 'title.english',
-                     'abstract', 'abstract.english']:
-            value = _highlight_whole_texism(value)
-
-        # A hit on authors may originate in several different fields, most
-        # of which are not displayed. And in any case, author names may be
-        # truncated. So instead of highlighting author names themselves, we
-        # set a 'flag' that can get picked up in the template and highlight
-        # the entire author field.
-        if field.startswith('author'):
-            field = 'author'
-            value = True
-        result['highlight'][field] = value
-
-    # If there is a hit in a TeX field, we prefer highlighting on that
-    # field, since other tokenizers will clobber the TeX.
-    for field in ['abstract', 'title']:
-        if f'{field}.tex' in result['highlight']:
-            result['highlight'][field] = \
-                result['highlight'].pop(f'{field}.tex')
-
-    for field in ['abstract.tex', 'abstract.english', 'abstract']:
-        if field in result['highlight']:
-            value = result['highlight'][field]
-            abstract_snippet = _preview(value)
-            result['preview']['abstract'] = abstract_snippet
-            result['highlight']['abstract'] = value
-            break
-    for field in ['title.english', 'title']:
-        if field in result['highlight']:
-            result['highlight']['title'] = result['highlight'][field]
-            break
-    return result
 
 
 def _to_document(raw: Response) -> Document:
@@ -208,14 +44,30 @@ def _to_document(raw: Response) -> Document:
         result[key] = value
     result['score'] = raw.meta.score
     if type(result['abstract']) is str:
-        result['preview']['abstract'] = _preview(result['abstract'])
-    result = _add_highlighting(result, raw)
+        result['preview']['abstract'] = preview(result['abstract'])
+    result = add_highlighting(result, raw)
     return Document(**result)   # type: ignore
     # See https://github.com/python/mypy/issues/3937
 
 
 def to_documentset(query: Query, response: Response) -> DocumentSet:
-    """Transform a response from ES to a :class:`.DocumentSet`."""
+    """
+    Transform a response from ES to a :class:`.DocumentSet`.
+
+    Parameters
+    ----------
+    query : :class:`.Query`
+        The original search query.
+    response : :class:`.Response`
+        The response from Elasticsearch.
+
+    Returns
+    -------
+    :class:`.DocumentSet`
+        The set of :class:`.Document`s responding to the query on the current
+        page, along with pagination metadata.
+
+    """
     max_pages = int(MAX_RESULTS/query.page_size)
     N_pages_raw = response['hits']['total']/query.page_size
     N_pages = int(floor(N_pages_raw)) + \

--- a/search/services/index/results.py
+++ b/search/services/index/results.py
@@ -17,6 +17,7 @@ from .util import MAX_RESULTS, TEXISM
 from .highlighting import add_highlighting, preview
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 
 
 def _to_document(raw: Response) -> Document:

--- a/search/services/index/results.py
+++ b/search/services/index/results.py
@@ -148,8 +148,8 @@ def _add_highlighting(result: dict, raw: Response) -> dict:
         # To guard against this while preserving highlighting, we move
         # any highlighting tags from within TeXisms to encapsulate the
         # entire TeXism.
-        if field in ['title', 'title_utf8', 'title.english', 'abstract',
-                     'abstract.english']:
+        if field in ['title', 'title.english',
+                     'abstract', 'abstract.english']:
             value = _highlight_whole_texism(value)
 
         # A hit on authors may originate in several different fields, most
@@ -164,20 +164,19 @@ def _add_highlighting(result: dict, raw: Response) -> dict:
 
     # If there is a hit in a TeX field, we prefer highlighting on that
     # field, since other tokenizers will clobber the TeX.
-    for field in ['abstract', 'abstract_utf8', 'title', 'title_utf8']:
+    for field in ['abstract', 'title']:
         if f'{field}.tex' in result['highlight']:
             result['highlight'][field] = \
                 result['highlight'].pop(f'{field}.tex')
 
-    for field in ['abstract.tex', 'abstract.english', 'abstract_utf8',
-                  'abstract']:
+    for field in ['abstract.tex', 'abstract.english', 'abstract']:
         if field in result['highlight']:
             value = result['highlight'][field]
             abstract_snippet = _preview(value)
             result['preview']['abstract'] = abstract_snippet
             result['highlight']['abstract'] = value
             break
-    for field in ['title.english', 'title_utf8', 'title']:
+    for field in ['title.english', 'title']:
         if field in result['highlight']:
             result['highlight']['title'] = result['highlight'][field]
             break

--- a/search/services/index/simple.py
+++ b/search/services/index/simple.py
@@ -30,4 +30,5 @@ def simple_search(search: Search, query: SimpleQuery) -> Search:
     q = SEARCH_FIELDS[query.search_field](query.value)
     search = search.query(q)
     search = sort(query, search)
+    print(search.to_dict())
     return search

--- a/search/services/index/simple.py
+++ b/search/services/index/simple.py
@@ -1,0 +1,33 @@
+"""Support for the simple search feature."""
+
+from elasticsearch_dsl import Search
+
+from search.domain import SimpleQuery
+
+from .prepare import SEARCH_FIELDS
+from .util import sort
+
+
+def simple_search(search: Search, query: SimpleQuery) -> Search:
+    """
+    Prepare a :class:`.Search` from a :class:`.SimpleQuery`.
+
+    Parameters
+    ----------
+    search : :class:`.Search`
+        An Elasticsearch DSL search object, in preparation for execution.
+    query : :class:`.SimpleQuery`
+        A query originating from the simple search controller.
+
+    Returns
+    -------
+    :class:`.Search`
+        The passed search object, updated with query parameters that implement
+        the passed :class:`.SimpleQuery`.
+
+    """
+    search = search.filter("term", is_current=True)
+    q = SEARCH_FIELDS[query.search_field](query.value)
+    search = search.query(q)
+    search = sort(query, search)
+    return search

--- a/search/services/index/tests/test_results.py
+++ b/search/services/index/tests/test_results.py
@@ -1,7 +1,7 @@
 """Tests for :mod:`search.services.index`."""
 
 from unittest import TestCase, mock
-from search.services.index import results
+from search.services.index import highlighting
 
 
 class TestResultsHighlightAbstract(TestCase):
@@ -24,9 +24,9 @@ class TestResultsHighlightAbstract(TestCase):
 
     def test_preview(self):
         """Generate a preview that is smaller than/equal to fragment size."""
-        preview = results._preview(self.value, fragment_size=350,
-                                   start_tag=self.start_tag,
-                                   end_tag=self.end_tag)
+        preview = highlighting.preview(self.value, fragment_size=350,
+                                       start_tag=self.start_tag,
+                                       end_tag=self.end_tag)
         self.assertEqual(len(preview), 338)
 
     def test_preview_with_close_highlights(self):
@@ -46,7 +46,8 @@ class TestResultsHighlightAbstract(TestCase):
         )
         start_tag = "<span class=\"has-text-success has-text-weight-bold mathjax\">"
         end_tag = "</span>"
-        preview = results._preview(value, start_tag=start_tag, end_tag=end_tag)
+        preview = highlighting.preview(value, start_tag=start_tag,
+                                       end_tag=end_tag)
 
 
 class TestResultsEndSafely(TestCase):
@@ -69,27 +70,30 @@ class TestResultsEndSafely(TestCase):
 
     def test_end_safely_from_start(self):
         """No TeXisms/HTML are found within the desired fragment size."""
-        end = results._end_safely(self.value, 45, start_tag=self.start_tag,
-                                  end_tag=self.end_tag)
+        end = highlighting._end_safely(self.value, 45,
+                                       start_tag=self.start_tag,
+                                       end_tag=self.end_tag)
         self.assertEqual(end, 45, "Should end at the desired fragment length.")
 
     def test_end_safely_before_texism(self):
         """End before TeXism when desired fragment size would truncate."""
-        end = results._end_safely(self.value, 55, start_tag=self.start_tag,
-                                  end_tag=self.end_tag)
+        end = highlighting._end_safely(self.value, 55,
+                                       start_tag=self.start_tag,
+                                       end_tag=self.end_tag)
         # print(self.value[:end])
         self.assertEqual(end, 50, "Should end before the start of the TeXism.")
 
     def test_end_safely_before_html(self):
         """End before HTML when desired fragment size would truncate."""
-        end = results._end_safely(self.value, 215, start_tag=self.start_tag,
-                                  end_tag=self.end_tag)
+        end = highlighting._end_safely(self.value, 215,
+                                       start_tag=self.start_tag,
+                                       end_tag=self.end_tag)
         # print(self.value[:end])
         self.assertEqual(end, 213, "Should end before the start of the tag.")
 
     def test_end_safely_after_html_with_tolerance(self):
         """End before HTML when desired fragment size would truncate."""
-        end = results._end_safely(self.value, 275,
-                                  start_tag=self.start_tag,
-                                  end_tag=self.end_tag)
+        end = highlighting._end_safely(self.value, 275,
+                                       start_tag=self.start_tag,
+                                       end_tag=self.end_tag)
         self.assertEqual(end, 275, "Should end after the closing tag.")

--- a/search/services/index/tests/tests.py
+++ b/search/services/index/tests/tests.py
@@ -128,9 +128,9 @@ class TestWildcardSearch(TestCase):
 
         self.assertTrue(wildcard, "Wildcard should be detected")
         self.assertEqual(qs, qs_escaped, "The querystring should be unchanged")
-        self.assertEqual(
+        self.assertIsInstance(
             Q_('match', 'title', qs),
-            index.Q('wildcard', title=qs),
+            type(index.Q('wildcard', title=qs)),
             "Wildcard Q object should be generated"
         )
 
@@ -141,9 +141,9 @@ class TestWildcardSearch(TestCase):
 
         self.assertEqual(qs_escaped, '"Foo t\*"', "Wildcard should be escaped")
         self.assertFalse(wildcard, "Wildcard should not be detected")
-        self.assertEqual(
+        self.assertIsInstance(
             Q_('match', 'title', qs),
-            index.Q('match', title='"Foo t\*"'),
+            type(index.Q('match', title='"Foo t\*"')),
             "Wildcard Q object should not be generated"
         )
 
@@ -155,9 +155,9 @@ class TestWildcardSearch(TestCase):
         self.assertEqual(qs_escaped, '"Fo\*o t\*"',
                          "Both wildcards should be escaped")
         self.assertFalse(wildcard, "Wildcard should not be detected")
-        self.assertEqual(
+        self.assertIsInstance(
             Q_('match', 'title', qs),
-            index.Q('match', title='"Fo\*o t\*"'),
+            type(index.Q('match', title='"Fo\*o t\*"')),
             "Wildcard Q object should not be generated"
         )
 
@@ -169,9 +169,9 @@ class TestWildcardSearch(TestCase):
         self.assertEqual(qs_escaped, '"Fo\? t\*"',
                          "Both wildcards should be escaped")
         self.assertFalse(wildcard, "Wildcard should not be detected")
-        self.assertEqual(
+        self.assertIsInstance(
             Q_('match', 'title', qs),
-            index.Q('match', title='"Fo\? t\*"'),
+            type(index.Q('match', title='"Fo\? t\*"')),
             "Wildcard Q object should not be generated"
         )
 
@@ -183,9 +183,9 @@ class TestWildcardSearch(TestCase):
         self.assertEqual(qs_escaped, '"Fo\? t\*" said the *',
                          "Wildcards in literal should be escaped")
         self.assertTrue(wildcard, "Wildcard should be detected")
-        self.assertEqual(
+        self.assertIsInstance(
             Q_('match', 'title', qs),
-            index.Q('wildcard', title='"Fo\? t\*" said the *'),
+            type(index.Q('wildcard', title='"Fo\? t\*" said the *')),
             "Wildcard Q object should be generated"
         )
 
@@ -198,9 +198,9 @@ class TestWildcardSearch(TestCase):
                          "Wildcards in literal should be escaped")
         self.assertTrue(wildcard, "Wildcard should be detected")
 
-        self.assertEqual(
+        self.assertIsInstance(
             Q_('match', 'title', qs),
-            index.Q('wildcard', title='"Fo\?" s* "yes\*" o?'),
+            type(index.Q('wildcard', title='"Fo\?" s* "yes\*" o?')),
             "Wildcard Q object should be generated"
         )
 

--- a/search/services/index/tests/tests.py
+++ b/search/services/index/tests/tests.py
@@ -7,6 +7,7 @@ from elasticsearch_dsl import Search, Q
 from elasticsearch_dsl.query import Range, Match, Bool, Nested
 
 from search.services import index
+from search.services.index import advanced
 from search.services.index.util import wildcardEscape, Q_
 from search.domain import Query, FieldedSearchTerm, DateRange, Classification,\
     AdvancedQuery, FieldedSearchList, ClassificationList, SimpleQuery, \
@@ -238,7 +239,7 @@ class TestPrepare(TestCase):
             )
         )
         try:
-            terms = index.prepare._group_terms(query)
+            terms = advanced._group_terms(query)
         except AssertionError:
             self.fail('Should result in a single group')
         self.assertEqual(expected, terms)
@@ -260,7 +261,7 @@ class TestPrepare(TestCase):
             FieldedSearchTerm(operator='AND', field='title', term='foo')
         )
         try:
-            terms = index.prepare._group_terms(query)
+            terms = advanced._group_terms(query)
         except AssertionError:
             self.fail('Should result in a single group')
         self.assertEqual(expected, terms)

--- a/search/services/index/util.py
+++ b/search/services/index/util.py
@@ -6,7 +6,9 @@ from string import punctuation
 
 from elasticsearch_dsl import Search, Q, SF
 
+from search.domain import Query
 from .exceptions import QueryError
+
 
 # We'll compile this ahead of time, since it gets called quite a lot.
 STRING_LITERAL = re.compile(r"(['\"][^'\"]*['\"])")
@@ -18,11 +20,9 @@ TEXISM = re.compile(r'(\$[^\$]+\$)')
 MAX_RESULTS = 10_000
 """This is the maximum result offset for pagination."""
 
-HIGHLIGHT_TAG_OPEN = '<span class="search-hit mathjax">'
-HIGHLIGHT_TAG_CLOSE = '</span>'
-
 SPECIAL_CHARACTERS = ['+', '-', '=', '&&', '||', '>', '<', '!', '(', ')', '{',
                       '}', '[', ']', '^', '~', ':', '\\', '/']
+DEFAULT_SORT = ['_score', '-announced_date_first', '_doc']
 
 
 def wildcardEscape(querystring: str) -> Tuple[str, bool]:
@@ -96,6 +96,7 @@ def escape(term: str) -> str:
 
 
 def strip_punctuation(s: str) -> str:
+    """Remove all punctuation characters from a string."""
     return ''.join([c for c in s if c not in punctuation])
 
 
@@ -103,3 +104,15 @@ def remove_single_characters(term: str) -> str:
     """Remove any single characters in the search string."""
     return ' '.join([part for part in term.split()
                      if len(strip_punctuation(part)) > 1])
+
+
+def sort(query: Query, search: Search) -> Search:
+    """Apply sorting to a :class:`.Search`."""
+    if not query.order:
+        sort_params = DEFAULT_SORT
+    else:
+        direction = '-' if query.order.startswith('-') else ''
+        sort_params = [query.order, f'{direction}paper_id_v']
+    if sort_params is not None:
+        search = search.sort(*sort_params)
+    return search

--- a/search/services/index/util.py
+++ b/search/services/index/util.py
@@ -75,14 +75,14 @@ def strip_tex(term: str) -> str:
     return re.sub(TEXISM, '', term).strip()
 
 
-def Q_(qtype: str, field: str, value: str, boost: int = 1) -> Q:
+def Q_(qtype: str, field: str, value: str, operator: str = 'or') -> Q:
     """Construct a :class:`.Q`, but handle wildcards first."""
     value, wildcard = wildcardEscape(value)
     if wildcard:
-        return Q('wildcard', **{field: {'value': value, 'boost': boost}})
+        return Q('wildcard', **{field: {'value': value.lower()}})
     if 'match' in qtype:
-        return Q(qtype, **{field: {'query': value, 'boost': boost}})
-    return Q(qtype, **{field: value}, boost=boost)
+        return Q(qtype, **{field: value})
+    return Q(qtype, **{field: value}, operator=operator)
 
 
 def escape(term: str) -> str:

--- a/search/templates/search/advanced_search.html
+++ b/search/templates/search/advanced_search.html
@@ -32,7 +32,6 @@
     <div class="box">
       <form method="GET" action="{{ url_for('ui.advanced_search') }}">
         {{ form.advanced|safe }}
-
         {# Field-specific search term fieldset. #}
         <section data-toggle="fieldset" id="terms-fieldset">
           {% for entry in form.terms.entries %}
@@ -344,6 +343,9 @@
   {% if show_form %}
     {{ advanced_query(form) }}
   {% else %}
+    {% if has_classic_format %}
+      {{ search_macros.show_classic_author_search() }}
+    {% endif %}
     <p class="subtitle is-5">Refine your query: <a href="{{ current_url_sans_parameters('advanced') }}">{{ query }}</a> or <a href="{{ url_for('ui.advanced_search') }}">Start a new search</a></p>
     {% if results %}
         {{ search_macros.size_and_order(form, url_for('ui.advanced_search')) }}

--- a/search/templates/search/search-macros.html
+++ b/search/templates/search/search-macros.html
@@ -158,14 +158,10 @@
     {# Note: mathjax class should be applied to any element that requires MathJax processing #}
     <p class="title is-5 mathjax">
 
-      {% if result.highlight.title_utf8 %}
-        {{ result.highlight.title_utf8 | safe }}
+      {% if result.highlight.title %}
+        {{ result.highlight.title | safe }}
       {% else %}
-        {% if result.highlight.title %}
-          {{ result.highlight.title | safe }}
-        {% else %}
-          {{ result.title_utf8 }}
-        {% endif %}
+        {{ result.title }}
       {% endif %}
     </p>
     <p class="authors">

--- a/search/templates/search/search-macros.html
+++ b/search/templates/search/search-macros.html
@@ -233,3 +233,11 @@
     {%- endif -%}
   {%- endfor -%}
 {%- endmacro -%}
+
+{% macro show_classic_author_search() -%}
+  <article class="message is-warning">
+    <div class="message-body">
+      <p>For best results searching author names, use format <code>surname, initial</code> OR <code>surname, forename</code>. Separate individual authors with <code>;</code> semicolons.</p>
+    </div>
+  </article>
+{%- endmacro %}

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -12,6 +12,9 @@
 
 {% block within_content %}
   <form method="GET" action="{{ url_for('ui.search') }}" {% if not query and not results %} class="breathe-vertical" {% endif %} aria-role="search">
+    {% if has_classic_format %}
+      {{ search_macros.show_classic_author_search() }}
+    {% endif %}
     <div class="field has-addons-tablet">
       <div class="control is-expanded">
         <label for="query" class="hidden-label">Search term or terms</label>

--- a/tests/test_advanced_search.py
+++ b/tests/test_advanced_search.py
@@ -1,0 +1,26 @@
+from unittest import TestCase, mock
+
+from arxiv import taxonomy, status
+from search.factory import create_ui_web_app
+
+
+class TestAdvancedSearch(TestCase):
+    """Test for the advanced search UI."""
+
+    def setUp(self):
+        """Instantiate the UI application."""
+        self.app = create_ui_web_app()
+        self.client = self.app.test_client()
+
+    def test_archive_shortcut(self):
+        """User requests a sub-path with classification archive."""
+        for archive in taxonomy.ARCHIVES.keys():
+            response = self.client.get(f'/{archive}')
+            self.assertEqual(response.status_code, status.HTTP_200_OK,
+                             "Should support shortcut for archive {archive}")
+
+    def test_nonexistant_archive_shortcut(self):
+        """User requests a sub-path with non-existant archive."""
+        response = self.client.get('/fooarchive')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND,
+                         "Should return a 404 error")


### PR DESCRIPTION
Things were getting way too complex, which made search difficult to debug and to reason about. This is an attempt to make things much simpler.

One big change is that "all fields" is not just a disjunction of queries for each field. This introduces a ``combined`` field in the index that is used as the primary search document. A query against ``combined`` is conjoined with a modified disjunct (need only partial match on a field) across queries for each field (must also match at least one field-based search), so that we get hit highlighting. There are a few small things to wrap up on the "modified" part.

I also removed non-utf8 fields from the search document. Now title and abstract are populated from their utf8 counterparts in DocMeta (need to clean up a couple of tests about that).

This does simplify the author search logic a bit, by embracing the limitations of what we can know. The big change is that it does not try to use the initials from a full forename as it did before. E.g. "Doe, J" will match "John Doe" and "Jane Doe", but "Jane Doe" will not match "J Doe" nor "John Doe". This would imply that we revert to the initial form for abs page links, and I've updated the author URL builder here as well.

Still a few things to do, but eager for your reactions.