### PR TITLE
ARXIVNG-556 Audit tool for missing records

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ parameter.
 To check for missing records, use ``audit.py``:
 
 ```bash
-ELASTICSEARCH_HOST=127.0.0.1 pipenv run python audit.py -l list_of_papers.txt -o missing.txt
+ELASTICSEARCH_HOST=127.0.0.1 ELASTICSEARCH_INDEX=arxiv pipenv run python audit.py -l list_of_papers.txt -o missing.txt
 ```
 
 ### Flask dev server

--- a/README.md
+++ b/README.md
@@ -47,13 +47,19 @@ is only accessible from the CUL network.
 ```bash
 pipenv install
 FLASK_APP=app.py FLASK_DEBUG=1 ELASTICSEARCH_HOST=127.0.0.1 pipenv run python create_index.py
-FLASK_APP=app.py FLASK_DEBUG=1 ELASTICSEARCH_HOST=127.0.0.1 pipenv run python populate_test_metadata.py
+FLASK_APP=app.py FLASK_DEBUG=1 ELASTICSEARCH_HOST=127.0.0.1 pipenv run python bulk_index.py
 ```
 
-``populate_test_metadata.py`` without parameters populate the index with the
+``bulk_index.py`` without parameters populate the index with the
 list of papers defined in ``tests/data/sample.json``. It take several minutes
 to run. Individual paper IDs may be specified with the ``--paper_id``
 parameter.
+
+To check for missing records, use ``audit.py``:
+
+```bash
+ELASTICSEARCH_HOST=127.0.0.1 pipenv run python audit.py -l list_of_papers.txt -o missing.txt
+```
 
 ### Flask dev server
 

--- a/audit.py
+++ b/audit.py
@@ -1,0 +1,115 @@
+"""Check for missing papers in the index."""
+
+import time
+import os
+import csv
+from multiprocessing import Pool
+from functools import reduce
+from operator import concat
+from typing import List, Tuple
+
+import click
+
+from search.factory import create_ui_web_app
+
+app = create_ui_web_app()
+
+
+def exists(chunk: List[str]) -> List[Tuple[str, bool]]:
+    """
+    Check the status of a chunk of paper IDs.
+
+    Parameters
+    ----------
+    chunk : list
+        Each item should be a paper ID with a version affix.
+
+    Returns
+    -------
+    list
+        Items are paper ID, bool (exists) tuples.
+
+    """
+    with app.app_context():
+        from search.services import index
+        status = []
+        for ident in chunk:
+            time.sleep(0.05)    # TODO: make this configurable?
+            status.append((ident, index.exists(ident)))
+        return status
+
+
+@app.cli.command()
+@click.option('--id_list', '-l',
+              help="Index paper IDs in a file (one ID per line)")
+@click.option('--batch-size', '-b', type=int, default=1_600,
+              help="Number of records to process each iteration")
+@click.option('--n-workers', '-n', type=int, default=8, help="Num of workers")
+@click.option('--output', '-o', help="File in which missing IDs are stored")
+def audit(id_list: str, batch_size: int, n_workers: int, output: str):
+    """
+    Check the index for missing papers.
+
+    Uses HEAD requests to the document endpoint using each paper ID in the
+    provided list. Uses multiprocessing with a configurable number of worker
+    processes to speed things up.
+
+    Parameters
+    ----------
+    id_list : str
+        Should be a path to a file with paper IDs. There should be one paper ID
+        per line. Paper IDs should include version affixes.
+    batch_size : int
+        Number of records per batch. Each batch is divided into equal chunks
+        and distributed across workers. Smaller batches mean more frequent
+        updates/checkpoints. Must be divisible by the number of workers.
+        Default: 1,600.
+    n_workers : int
+        Number of worker processes to run for each batch. Default: 8.
+    output : str
+        Path to a file into which to deposit paper IDs not found in the index.
+
+    """
+    if batch_size % n_workers > 0:
+        raise click.ClickException(
+            "batch size must be divisible by the number of workers"
+        )
+    chunk_size = int(round(batch_size/n_workers))
+
+    if not os.path.exists(id_list):
+        raise click.ClickException("no such file")
+
+    # Load paper IDs to check.
+    with open(id_list) as f:
+        data = [row[0] for row in csv.reader(f)]
+
+    # Create the output file.
+    with open(output, 'w') as f:
+        f.write('')
+
+    N_results = 0
+    N_total = len(data)
+
+    with click.progressbar(length=N_total, label='Papers checked') as bar:
+        # We do this in batches, so that we can track and save as we go.
+        for i in range(0, len(data), batch_size):
+            batch = data[i:i + batch_size]
+            chunks = [batch[c:c + chunk_size]
+                      for c in range(0, batch_size, chunk_size)]
+
+            with Pool(n_workers) as p:
+                results = reduce(concat, p.map(exists, chunks))
+
+            # Write one missing paper ID per line.
+            with open(output, 'a') as f:       # Append to output file.
+                for ident, status in results:
+                    if status:
+                        continue
+                    f.write(f'{ident}\n')
+
+            N_results += len(results)
+            bar.update(N_results)
+
+
+if __name__ == '__main__':
+    audit()

--- a/search/agent/consumer.py
+++ b/search/agent/consumer.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 
 import json
 import os
+import time
 from typing import List, Any, Optional
 from arxiv.base import logging
 from search.services import metadata, index
@@ -295,6 +296,7 @@ class MetadataRecordProcessor(BaseConsumer):
             documents failed.
 
         """
+        time.sleep(0.1)
         logger.info(f'Processing record {record["SequenceNumber"]}')
         if self._error_count > self.MAX_ERRORS:
             raise IndexingFailed('Too many errors')

--- a/search/services/index/__init__.py
+++ b/search/services/index/__init__.py
@@ -123,7 +123,7 @@ class SearchSession(object):
         """
         self.index = index
         self.mapping = mapping
-        self.document_type = 'document'
+        self.doc_type = 'document'
         use_ssl = True if scheme == 'https' else False
         http_auth = '%s:%s' % (user, password) if user else None
 
@@ -211,7 +211,7 @@ class SearchSession(object):
         with handle_es_exceptions():
             ident = document.id if document.id else document.paper_id
             logger.debug(f'{ident}: index document')
-            self.es.index(index=self.index, doc_type=self.document_type,
+            self.es.index(index=self.index, doc_type=self.doc_type,
                           id=ident, body=document)
 
     def bulk_add_documents(self, documents: List[Document],
@@ -241,7 +241,7 @@ class SearchSession(object):
         with handle_es_exceptions():
             actions = ({
                 '_index': self.index,
-                '_type': self.document_type,
+                '_type': self.doc_type,
                 '_id': document.id,
                 '_source': asdict(document)
             } for document in documents)
@@ -274,7 +274,7 @@ class SearchSession(object):
 
         """
         with handle_es_exceptions():
-            record = self.es.get(index=self.index, doc_type=self.document_type,
+            record = self.es.get(index=self.index, doc_type=self.doc_type,
                                  id=document_id)
 
         if not record:
@@ -336,7 +336,8 @@ class SearchSession(object):
     def exists(self, paper_id_v: str) -> bool:
         """Determine whether a paper exists in the index."""
         with handle_es_exceptions():
-            return self.es.exists(self.index, self.document_type, paper_id_v)
+            ex: bool = self.es.exists(self.index, self.doc_type, paper_id_v)
+            return ex
 
 
 def init_app(app: object = None) -> None:


### PR DESCRIPTION
Added the script ``audit.py`` in the root of the project, implemented with click. This takes a list of paper IDs (including version affix), and outputs a list of missing paper IDs. A full scan may take one to three hours, depending on your internet connection. 

From the docstring:

```
Check the index for missing papers.

    Uses HEAD requests to the document endpoint using each paper ID in the
    provided list. Uses multiprocessing with a configurable number of worker
    processes to speed things up.

    Parameters
    ----------
    id_list : str
        Should be a path to a file with paper IDs. There should be one paper ID
        per line. Paper IDs should include version affixes.
    batch_size : int
        Number of records per batch. Each batch is divided into equal chunks
        and distributed across workers. Smaller batches mean more frequent
        updates/checkpoints. Must be divisible by the number of workers.
        Default: 1,600.
    n_workers : int
        Number of worker processes to run for each batch. Default: 8.
    output : str
        Path to a file into which to deposit paper IDs not found in the index.
```

For example:

```bash
ELASTICSEARCH_HOST=127.0.0.1 pipenv run python audit.py -l list_of_papers.txt -o missing.txt
```