### PR TITLE
ARXIVNG-741 order of initials is respected in author name queries

### DIFF
--- a/mappings/DocumentMapping.json
+++ b/mappings/DocumentMapping.json
@@ -55,6 +55,17 @@
             "english_stop"
           ]
         },
+        "author_simple": {
+          "type": "custom",
+          "tokenizer": "whitespace",
+          "char_filter": [
+            "strip_dots_commas"
+          ],
+          "filter": [
+            "icu_folding",
+            "lowercase"
+          ]
+        },
         "author_folding": {
           "type": "custom",
           "tokenizer": "whitespace",
@@ -89,6 +100,12 @@
           ]
         },
         "folding": {
+          "filter": [
+            "icu_folding",
+            "lowercase"
+          ]
+        },
+        "author_simple": {
           "filter": [
             "icu_folding",
             "lowercase"
@@ -162,12 +179,12 @@
               }
             },
             "initials": {
-              "type": "keyword",
-              "normalizer": "author_folding",
+              "type": "text",
+              "analyzer": "author_simple",
               "fields": {
                 "folded": {
                   "type": "keyword",
-                  "normalizer": "author_folding"
+                  "normalizer": "author_simple"
                 }
               }
             },

--- a/search/process/tests.py
+++ b/search/process/tests.py
@@ -43,7 +43,7 @@ class TestTransformMetdata(TestCase):
         self.assertEqual(doc.authors[0]['full_name'], 'B. Ivan Dole',
                          "full_name should be generated from first_name and"
                          " last_name")
-        self.assertEqual(doc.authors[0]['initials'], ["B", "I"],
+        self.assertEqual(doc.authors[0]['initials'], "B I",
                          "initials should be generated from first name")
 
     def test_authors_freeform(self):
@@ -72,7 +72,7 @@ class TestTransformMetdata(TestCase):
         self.assertEqual(doc.owners[0]['full_name'], 'B. Ivan Dole',
                          "full_name should be generated from first_name and"
                          " last_name")
-        self.assertEqual(doc.owners[0]['initials'], ["B", "I"],
+        self.assertEqual(doc.owners[0]['initials'], "B I",
                          "initials should be generated from first name")
 
     def test_submitted_date(self):

--- a/search/process/transform.py
+++ b/search/process/transform.py
@@ -46,8 +46,7 @@ def _transformAuthor(author: dict) -> Optional[Dict]:
     if (not author['last_name']) and (not author['first_name']):
         return None
     author['full_name'] = re.sub(r'\s+', ' ', f"{author['first_name']} {author['last_name']}")
-    author['initials'] = [pt[0] for pt in author['first_name'].split() if pt]
-    # initials = ' '.join(author["initials"])
+    author['initials'] = " ".join([pt[0] for pt in author['first_name'].split() if pt])
     name_parts = author['first_name'].split() + author['last_name'].split()
     author['full_name_initialized'] = ' '.join([part[0] for part in name_parts[:-1]] + [name_parts[-1]])
     return author


### PR DESCRIPTION
Unfortunately this will require a reindex from docmeta, as it changes the structure of the data (``authors.initials`` goes from being a list to being a str). I can't say that I'm 100.0% happy with this. It's difficult to get precision on forename parts (e.g. initials occur in order) and recall (e.g. with wildcards). In this version, if the forename part of a structured query contains a wildcard, we do a query_string query on the forename. Otherwise, we do a match_phrase_prefix, which preserves term order.