### PR TITLE
ARXIVNG-766 proper escaping of hyphens, minor fix to all-fields search

### DIFF
--- a/search/services/index/authors.py
+++ b/search/services/index/authors.py
@@ -84,7 +84,8 @@ def part_query(term: str, path: str = "authors") -> Q:
 
         # Doing a query string so that wildcards and literals are just handled.
         q_surname = Q("query_string", fields=[f"{path}.last_name"],
-                      query=escape(surname), default_operator='AND',
+                      query=escape(surname),
+                      default_operator='AND',
                       allow_leading_wildcard=False)
 
         if forename:
@@ -206,7 +207,8 @@ def author_query(term: str, operator: str = 'AND') -> Q:
     # A query_string query on the combined field will yield matches among
     # authors.
     q = Q('query_string', fields=['authors_combined'],
-          query=escape(term, quotes=True), default_operator='and')
+          query=escape(term, quotes=True),
+          default_operator='and')
 
     # A nested query_string query on full name will match within individual
     # authors.

--- a/search/services/index/util.py
+++ b/search/services/index/util.py
@@ -21,7 +21,7 @@ MAX_RESULTS = 10_000
 """This is the maximum result offset for pagination."""
 
 SPECIAL_CHARACTERS = ['+', '=', '&&', '||', '>', '<', '!', '(', ')', '{',
-                      '}', '[', ']', '^', '~', ':', '\\', '/']
+                      '}', '[', ']', '^', '~', ':', '\\', '/', '-']
 DEFAULT_SORT = ['_score', '-announced_date_first', '_doc']
 
 


### PR DESCRIPTION
We weren't escaping hyphens correctly. I also noticed that, since we are using whitespace tokenization in the combined field, there was a discrepancy between queries in all field searches and some searches in specific fields.