### PR TITLE
ARXIVNG-775 handling wildcards in msc and acm classification fields

### DIFF
--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -19,7 +19,7 @@ from arxiv.base import logging
 
 from search.domain import SimpleQuery, Query, AdvancedQuery, Classification
 from .util import strip_tex, Q_, is_tex_query, is_literal_query, escape, \
-    wildcardEscape, remove_single_characters
+    wildcardEscape, remove_single_characters, has_wildcard
 from .highlighting import HIGHLIGHT_TAG_OPEN, HIGHLIGHT_TAG_CLOSE
 from .authors import author_query, author_id_query, orcid_query
 
@@ -66,10 +66,14 @@ def _query_report_num(term: str, boost: int = 1, operator: str = 'and') -> Q:
 
 
 def _query_acm_class(term: str, operator: str = 'and') -> Q:
+    if has_wildcard(term):
+        return Q("wildcard", acm_class=term)
     return Q("match", acm_class={"query": term, "operator": operator})
 
 
 def _query_msc_class(term: str, operator: str = 'and') -> Q:
+    if has_wildcard(term):
+        return Q("wildcard", msc_class=term)
     return Q("match", msc_class={"query": term, "operator": operator})
 
 

--- a/search/services/index/util.py
+++ b/search/services/index/util.py
@@ -59,6 +59,12 @@ def wildcardEscape(querystring: str) -> Tuple[str, bool]:
     return querystring, wildcard
 
 
+def has_wildcard(term: str) -> bool:
+    """Determine whether or not ``term`` contains a wildcard."""
+    return (('*' in term or '?' in term) and not
+            (term.startswith('*') or term.startswith('?')))
+
+
 def is_literal_query(term: str) -> bool:
     """Determine whether the term is intended to be treated as a literal."""
     # return re.match('"[^"]+"', term) is not None


### PR DESCRIPTION
We weren't offering a wildcard query on those fields. This checks for wildcards, and if present returns a wildcard query instead of a match. 