### PR TITLE
ARXIVNG-1001 fixed bug that prevented author-owner matches when individuating name parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ ENV/
 src/
 temp/
 .DS_Store
+
+to_index/

--- a/Dockerfile-elasticsearch
+++ b/Dockerfile-elasticsearch
@@ -1,6 +1,6 @@
 # arxiv/eleasticsearch
 #
-# Runs Elasticsearch 6.1.1, with additional plugins.
+# Runs Elasticsearch 6.2.4, with additional plugins.
 #
 # To run, use the ``docker-compose.yml`` config in this directory to spin up
 # alongside Kibana. Or:
@@ -12,7 +12,7 @@
 #
 # ES should be available on tcp://localhost:9200.
 
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.1.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.2.4
 
 # Install plugins.
 #

--- a/Dockerfile-kibana
+++ b/Dockerfile-kibana
@@ -1,6 +1,6 @@
 # arxiv/kibana
 #
-# Runs Kibana 6.1.1. This Dockerfile is not strictly necessary, but it here
+# Runs Kibana 6.2.4. This Dockerfile is not strictly necessary, but it here
 # in case we want to run any additional plugins.
 #
 # As of version 0.1, this is here for local development purposes only and is
@@ -10,4 +10,4 @@
 # alongside Elasticsearch.
 
 
-FROM docker.elastic.co/kibana/kibana:6.1.1
+FROM docker.elastic.co/kibana/kibana:6.2.4

--- a/bulk_index.py
+++ b/bulk_index.py
@@ -46,7 +46,7 @@ def populate(print_indexable: bool, paper_id: str, id_list: str,
     index_chunk_size = 250
     chunk: List[str] = []
     meta: List[DocMeta] = []
-
+    index.current_session().create_index()
     try:
         with click.progressbar(length=approx_size,
                                label='Papers indexed') as index_bar:

--- a/search/process/tests.py
+++ b/search/process/tests.py
@@ -311,14 +311,14 @@ class TestTransformMetdata(TestCase):
         doc = transform.to_search_document(meta)
         self.assertEqual(doc.acm_class, ["F.4.1", "D.2.4"])
 
-    def test_metadata_id(self):
+    def test_doi(self):
         """Field ``doi`` is populated from ``doi``."""
         meta = DocMeta(**{
             'paper_id': '1234.56789',
             'doi': '10.1103/PhysRevD.76.104043'
         })
         doc = transform.to_search_document(meta)
-        self.assertEqual(doc.doi, '10.1103/PhysRevD.76.104043')
+        self.assertEqual(doc.doi, ['10.1103/PhysRevD.76.104043'])
 
     def test_metadata_id(self):
         """Field ``comments`` is populated from ``comments_utf8``."""

--- a/search/services/index/authors.py
+++ b/search/services/index/authors.py
@@ -99,7 +99,7 @@ def part_query(term: str, path: str = "authors") -> Q:
             # corresponding term.
             else:
                 q_forename = Q("match_phrase_prefix",
-                               **{"authors__first_name": forename})
+                               **{f"{path}__first_name": forename})
 
             # It may be the case that the forename consists of initials or some
             # other prefix/partial forename. For a match of this kind, each


### PR DESCRIPTION
This turned out to be a pretty simple bug. The document path "authors" was hard-coded in a place where it aught to been set by a function parameter (i.e. variously using "authors" or "owners").