### PR TITLE
ARXIVNG-977 catch queries with terms that start with a wildcard

### DIFF
--- a/search/controllers/util.py
+++ b/search/controllers/util.py
@@ -18,6 +18,10 @@ def doesNotStartWithWildcard(form: Form, field: StringField) -> None:
         return
     if field.data.startswith('?') or field.data.startswith('*'):
         raise validators.ValidationError('Search cannot start with a wildcard')
+    if any([part.startswith('?') or part.startswith('*')
+            for part in field.data.split()]):
+        raise validators.ValidationError('Search terms cannot start with a'
+                                         ' wildcard')
 
 
 def stripWhiteSpace(value: str) -> str:


### PR DESCRIPTION
Many of the queries that we run involve subqueries that treat whitespace delimited terms separately, including `query_string` queries. We were checking for wildcard characters at the beginning of the query string, but not at the beginning of individual terms. This PR fixes that.