### PR TITLE
ARXIVNG-998 added support for searches by announcement year

### DIFF
--- a/search/services/index/tests/test_util.py
+++ b/search/services/index/tests/test_util.py
@@ -10,33 +10,31 @@ class TestMatchDatePartial(TestCase):
 
     def test_date_partial_only(self):
         """Term includes only a four-digit date partial."""
-        term = '1902'
-        ym, rmd = util.match_date_partial(term)
+        term, rmd = util.match_date('1902')
+        ym = util.match_date_partial(term)
         self.assertEqual(ym, '2019-02')
         self.assertEqual(rmd, '', "Should have no remainder")
 
     def test_in_word(self):
         """A false positive in a word."""
-        term = 'notasearch1902foradatepartial'
         with self.assertRaises(ValueError):
-            util.match_date_partial(term)
+            term, rmd = util.match_date('notasearch1902foradatepartial')
 
     def test_near_words(self):
         """Term includes date partial plus other terms."""
-        term = 'foo 1902 bar'
-        ym, rmd = util.match_date_partial(term)
+        term, rmd = util.match_date('foo 1902 bar')
+        ym = util.match_date_partial(term)
         self.assertEqual(ym, '2019-02')
         self.assertEqual(rmd, "foo bar", "Should have remainder")
 
     def test_out_of_range(self):
         """Term looks like a date partial, but is not a valid date."""
-        term = '0699'
-        with self.assertRaises(ValueError):
-            util.match_date_partial(term)
+        term, rmd = util.match_date('0699')
+        self.assertIsNone(util.match_date_partial(term))
 
     def test_last_millenium(self):
         """Term is for a pre-2000 paper."""
-        term = 'old paper 9505'
-        ym, rmd = util.match_date_partial(term)
+        term, rmd = util.match_date('old paper 9505')
+        ym = util.match_date_partial(term)
         self.assertEqual(ym, '1995-05')
         self.assertEqual(rmd, 'old paper', 'Should have a remainder')

--- a/search/services/index/util.py
+++ b/search/services/index/util.py
@@ -25,7 +25,7 @@ SPECIAL_CHARACTERS = ['+', '=', '&&', '||', '>', '<', '!', '(', ')', '{',
 DEFAULT_SORT = ['-announced_date_first', '_doc']
 
 DATE_PARTIAL = r"(?:^|[\s])(\d{2})((?:0[1-9]{1})|(?:1[0-2]{1}))(?:$|[\s])"
-"""Used to match parts of author IDs that encode the announcement date."""
+"""Used to match parts of paper IDs that encode the announcement date."""
 
 
 def wildcardEscape(querystring: str) -> Tuple[str, bool]:
@@ -127,9 +127,42 @@ def sort(query: Query, search: Search) -> Search:
     return search
 
 
-def match_date_partial(term: str) -> Tuple[str, str]:
+def match_date(term: str) -> Tuple[str, str]:
     """
-    Attempt to find a four-digit ID date partial (year + month).
+    Attempt to find date-related information in the query.
+
+    Parameters
+    ----------
+    term : str
+        Search term.
+
+    Returns
+    -------
+    tuple
+        First element is the responding date-related fragment, second element
+        is the remainder of `term` (without the date).
+
+    Raises
+    ------
+    ValueError
+        Raised if no date-related information is found in `term`.
+
+    """
+    match = re.search(r'(?:^|[\s]+)([0-9]{4}-[0-9]{2})(?:$|[\s]+)', term)
+    if match:
+        remainder = term[:match.start()] + " " + term[match.end():]
+        return match.group(1), remainder.strip()
+
+    match = re.search(r'(?:^|[\s]+)([0-9]{4})(?:$|[\s]+)', term)
+    if match:   # Looks like a year:
+        remainder = term[:match.start()] + " " + term[match.end():]
+        return match.group(1), remainder.strip()
+    raise ValueError('No date info detected')
+
+
+def match_date_partial(term: str) -> Optional[str]:
+    """
+    Convert a 4-digit ID date partial into a full year-month value.
 
     This can be used to search for papers by announcement date.
 
@@ -140,14 +173,8 @@ def match_date_partial(term: str) -> Tuple[str, str]:
 
     Returns
     -------
-    tuple
-        First element is date (str) in `yyyy-MM` format, second element is the
-        remainder of `term` (without the partial).
-
-    Raises
-    ------
-    ValueError
-        Raised if no date partial is found in `term`.
+    str
+        Date in `yyyy-MM` format, if found.
 
     """
     match = re.search(DATE_PARTIAL, term)
@@ -156,6 +183,5 @@ def match_date_partial(term: str) -> Tuple[str, str]:
         # This should be fine until 2091.
         century = 19 if int(year) >= 91 else 20
         date_partial = f"{century}{year}-{month}"   # year_month format in ES.
-        remainder = term[:match.start()] + " " + term[match.end():]
-        return date_partial, re.sub(r"\s+", " ", remainder).strip()
-    raise ValueError('Does not include an ID date partial')
+        return date_partial
+    return None


### PR DESCRIPTION
This was a bit wonky, since we were already looking for legacy announcement date partials in the ``yyMM`` format. So this PR builds on that functionality and also tries queries like ``yyyy`` and ``yyyy-MM``. 

This passes all of the automated tests, and my manual testing indicated the correct behavior, but it would be good to have some additional and independent manual testing.

Raise the PR into bug/ARXIVNG-977 since that's the basis for this branch, and #197 hasn't been merged yet.