### PR TITLE
ARXIVNG-978 implemented feature to hide abstracts in search results

### DIFF
--- a/search/controllers/advanced/__init__.py
+++ b/search/controllers/advanced/__init__.py
@@ -177,6 +177,7 @@ def _query_from_form(form: forms.AdvancedSearchForm) -> AdvancedQuery:
     order = form.order.data
     if order and order != 'None':
         q.order = order
+    q.hide_abstracts = form.abstracts.data == form.HIDE_ABSTRACTS
     return q
 
 
@@ -213,7 +214,8 @@ def _update_query_with_classification(q: AdvancedQuery, data: MultiDict) \
 def _update_query_with_terms(q: AdvancedQuery, terms_data: list) \
         -> AdvancedQuery:
     q.terms = FieldedSearchList([
-        FieldedSearchTerm(**term) for term in terms_data if term['term']    # type: ignore
+        FieldedSearchTerm(**term)       # type: ignore
+        for term in terms_data if term['term']
     ])
     return q
 

--- a/search/controllers/advanced/forms.py
+++ b/search/controllers/advanced/forms.py
@@ -188,3 +188,11 @@ class AdvancedSearchForm(Form):
         ('', 'Relevance')
     ], validators=[validators.Optional()], default='-announced_date_first')
     include_older_versions = BooleanField('Include older versions of papers')
+
+    HIDE_ABSTRACTS = 'hide'
+    SHOW_ABSTRACTS = 'show'
+
+    abstracts = RadioField('Abstracts', choices=[
+        (SHOW_ABSTRACTS, 'Show abstracts'),
+        (HIDE_ABSTRACTS, 'Hide abstracts')
+    ], default=SHOW_ABSTRACTS)

--- a/search/controllers/simple/__init__.py
+++ b/search/controllers/simple/__init__.py
@@ -235,6 +235,7 @@ def _query_from_form(form: SimpleSearchForm) -> SimpleQuery:
     q = SimpleQuery()
     q.search_field = form.searchtype.data
     q.value = form.query.data
+    q.hide_abstracts = form.abstracts.data == form.HIDE_ABSTRACTS
     order = form.order.data
     if order and order != 'None':
         q.order = order

--- a/search/controllers/simple/forms.py
+++ b/search/controllers/simple/forms.py
@@ -4,7 +4,7 @@ from datetime import date
 
 from wtforms import Form, BooleanField, StringField, SelectField, validators, \
     FormField, SelectMultipleField, DateField, ValidationError, FieldList, \
-    widgets
+    widgets, RadioField
 from wtforms.fields import HiddenField
 
 from search.controllers.util import doesNotStartWithWildcard, stripWhiteSpace
@@ -46,6 +46,14 @@ class SimpleSearchForm(Form):
         ('submitted_date', 'Submission date (oldest first)'),
         ('', 'Relevance')
     ], validators=[validators.Optional()], default='-announced_date_first')
+
+    HIDE_ABSTRACTS = 'hide'
+    SHOW_ABSTRACTS = 'show'
+
+    abstracts = RadioField('Abstracts', choices=[
+        (SHOW_ABSTRACTS, 'Show abstracts'),
+        (HIDE_ABSTRACTS, 'Hide abstracts')
+    ], default=SHOW_ABSTRACTS)
 
     def validate_query(form: Form, field: StringField) -> None:
         """Validate the length of the querystring, if searchtype is set."""

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -123,6 +123,7 @@ class Query:
     page_size: int = field(default=50)
     page_start: int = field(default=0)
     include_older_versions: bool = field(default=False)
+    hide_abstracts: bool = field(default=False)
 
     @property
     def page_end(self) -> int:

--- a/search/routes/ui.py
+++ b/search/routes/ui.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 blueprint = Blueprint('ui', __name__, url_prefix='/')
 
-PARAMS_TO_PERSIST = ['order', 'size']
+PARAMS_TO_PERSIST = ['order', 'size', 'hide_abstracts']
 """These parameters should be persisted in a cookie."""
 
 PARAMS_COOKIE_NAME = 'arxiv-search-parameters'

--- a/search/templates/search/advanced_search.html
+++ b/search/templates/search/advanced_search.html
@@ -246,6 +246,15 @@
           </fieldset>
         </section>
         <section>
+          <div class="field">
+            <div class="control">
+              {% for subfield in form.abstracts %}
+              <label class="radio">
+                {{ subfield }} {{ subfield.label.text }}
+              </label>
+              {% endfor %}
+            </div>
+          </div>
           <div class="level">
             <div class="level-left">
               <div class="level-item">
@@ -318,7 +327,7 @@
     <p class="subtitle is-5">Refine your query: <a href="{{ current_url_sans_parameters('advanced') }}">{{ query }}</a> or <a href="{{ url_for('ui.advanced_search') }}">Start a new search</a></p>
     {% if results %}
         {{ search_macros.size_and_order(form, url_for('ui.advanced_search')) }}
-        {{ search_macros.search_results(form, results, metadata, external_url, url_for_page, url_for_author_search, is_current) }}
+        {{ search_macros.search_results(form, results, metadata, external_url, url_for_page, url_for_author_search, is_current, query.hide_abstracts) }}
     {% endif %}
   {% endif %}
 {% endblock %}

--- a/search/templates/search/search-macros.html
+++ b/search/templates/search/search-macros.html
@@ -119,7 +119,7 @@
 {%- endmacro %}
 
 
-{% macro search_results(form, results, metadata, external_url, url_for_page, url_for_author_search, is_current) %}
+{% macro search_results(form, results, metadata, external_url, url_for_page, url_for_author_search, is_current, hide_abstracts) %}
 
 {% if metadata.total_pages > 1 %}
   {{ pagination(metadata, url_for_page) }}
@@ -171,6 +171,7 @@
       {% endfor -%}
       {% if result.authors | length > 25 %}, et al. ({{ result.authors | length - 25 }} additional authors not shown){% endif %}
     </p>
+    {% if not hide_abstracts %}
     <p class="abstract mathjax">
       <span class="has-text-black-bis has-text-weight-semibold">Abstract</span>:
         <span class="abstract-short has-text-grey-dark mathjax" id="{{result.id}}-abstract-short" style="display: inline;">
@@ -182,6 +183,7 @@
           <a class="is-size-7" style="white-space: nowrap;" onclick="document.getElementById('{{result.id}}-abstract-full').style.display = 'none'; document.getElementById('{{result.id}}-abstract-short').style.display = 'inline';">&#9651; Less</a>
         </span>
     </p>
+    {% endif %}
     <p class="is-size-7"><span class="has-text-black-bis has-text-weight-semibold">Submitted</span> {{ result.submitted_date.strftime('%-d %B, %Y') }}; {% if result.version > 1 %}<span class="has-text-black-bis has-text-weight-semibold">v1</span> submitted {{ result.submitted_date_first.strftime('%-d %B, %Y') }};{% endif %} <span class="has-text-black-bis has-text-weight-semibold">originally announced</span> {{ result.announced_date_first.strftime('%B %Y') }}. {% if not is_current(result) %}<span class="has-text-weight-bold">Latest version:</span> <a href="{{ external_url('browse', 'abstract', paper_id=result.latest) }}">{{ result.latest }}</a>.{% endif %}</p>
 
     {% if result.comments %}

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -39,6 +39,15 @@
           <button class="button is-link is-medium">Search</button>
       </div>
     </div>
+    <div class="field">
+      <div class="control is-size-7">
+        {% for subfield in form.abstracts %}
+        <label class="radio">
+          {{ subfield }} {{ subfield.label.text }}
+        </label>
+        {% endfor %}
+      </div>
+    </div>
     <div class="is-clearfix" style="height: 2.5em"> {# TODO - adjust this layout so that it matches across all forms less awkwardly #}
       <div class="is-pulled-right">
         {% if query %}
@@ -63,7 +72,7 @@
 
   {% if results %}
       {{ search_macros.size_and_order(form, url_for('ui.search')) }}
-      {{ search_macros.search_results(form, results, metadata, external_url, url_for_page, url_for_author_search, is_current) }}
+      {{ search_macros.search_results(form, results, metadata, external_url, url_for_page, url_for_author_search, is_current, query.hide_abstracts) }}
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Users can indicate whether to show or hide abstracts in search results. The last selection made by the user is stored in the preferences cookie. I would have preferred a checkbox, but since browsers don't send False values for checkboxes, we end up in an indeterminate situation when we're using the cookie. Hence the radio field.

Here's the simple search form:
![image 2](https://user-images.githubusercontent.com/3451594/42648732-bf563f60-85d5-11e8-9331-3b6434821dce.png)

Here's the advanced search form:
![image 3](https://user-images.githubusercontent.com/3451594/42648735-c0c5c280-85d5-11e8-8003-3f40bb569ee1.png)
