### PR TITLE
ARXIVNG-999 implemented route for archive-specific searches in simple interface

### DIFF
--- a/search/controllers/advanced/__init__.py
+++ b/search/controllers/advanced/__init__.py
@@ -133,7 +133,6 @@ def search(request_params: MultiDict) -> Response:
         else:
             logger.debug('form is invalid: %s', str(form.errors))
             if 'order' in form.errors or 'size' in form.errors:
-                print(form.errors, form.data)
                 # It's likely that the user tried to set these parameters
                 # manually, or that the search originated from somewhere else
                 # (and was configured incorrectly).

--- a/search/controllers/simple/__init__.py
+++ b/search/controllers/simple/__init__.py
@@ -7,17 +7,18 @@ to generate form HTML, validate request parameters, and produce informative
 error messages for the user.
 """
 
-from typing import Tuple, Dict, Any, Optional
+from typing import Tuple, Dict, Any, Optional, List
 
 from werkzeug.exceptions import InternalServerError, NotFound, BadRequest
 from werkzeug import MultiDict, ImmutableMultiDict
 from flask import url_for
 
-from arxiv import status, identifier
+from arxiv import status, identifier, taxonomy
 
 from arxiv.base import logging
 from search.services import index, fulltext, metadata
-from search.domain import Query, SimpleQuery, asdict
+from search.domain import Query, SimpleQuery, asdict, Classification, \
+    ClassificationList
 from search.controllers.util import paginate, catch_underscore_syntax
 
 from .forms import SimpleSearchForm
@@ -28,7 +29,8 @@ logger = logging.getLogger(__name__)
 Response = Tuple[Dict[str, Any], int, Dict[str, Any]]
 
 
-def search(request_params: MultiDict) -> Response:
+def search(request_params: MultiDict,
+           archives: Optional[List[str]] = None) -> Response:
     """
     Perform a simple search.
 
@@ -40,7 +42,9 @@ def search(request_params: MultiDict) -> Response:
 
     Parameters
     ----------
-    request_params : dict
+    request_params : :class:`.MultiDict`
+    archives : list
+        A list of archives within which the search should be performed.
 
     Returns
     -------
@@ -58,6 +62,9 @@ def search(request_params: MultiDict) -> Response:
         unexpected problem executing the query.
 
     """
+    if archives is not None and len(archives) == 0:
+        raise NotFound('No such archive')
+
     # We may need to intervene on the request parameters, so we'll
     # reinstantiate as a mutable MultiDict.
     if isinstance(request_params, ImmutableMultiDict):
@@ -116,6 +123,9 @@ def search(request_params: MultiDict) -> Response:
     if form.validate():
         logger.debug('form is valid')
         q = _query_from_form(form)
+
+        if archives is not None:
+            q = _update_with_archives(q, archives)
 
         # Pagination is handled outside of the form.
         q = paginate(q, request_params)
@@ -216,6 +226,26 @@ def retrieve_document(document_id: str) -> Response:
         logger.error('DocumentNotFound: %s', e)
         raise NotFound(f"Could not find a paper with id {document_id}") from e
     return {'document': result}, status.HTTP_200_OK, {}
+
+
+def _update_with_archives(q: SimpleQuery, archives: List[str]) -> Response:
+    """
+    Search within a group or archive.
+
+    Parameters
+    ----------
+    q : :class:`SimpleQuery`
+    groups_or_archives : str
+
+    Returns
+    -------
+    :class:`SimpleQuery`
+    """
+    logger.debug('Search within %s', archives)
+    q.primary_classification = ClassificationList(
+        [Classification(archive=archive) for archive in archives]
+    )
+    return q
 
 
 def _query_from_form(form: SimpleSearchForm) -> SimpleQuery:

--- a/search/converters.py
+++ b/search/converters.py
@@ -1,0 +1,29 @@
+"""URL conversion for paths containing arXiv groups or archives."""
+
+import re
+from typing import List, Optional
+from arxiv import taxonomy
+from werkzeug.routing import BaseConverter, ValidationError
+
+
+class ArchiveConverter(BaseConverter):
+    """Route converter for arXiv IDs."""
+
+    def to_python(self, value: str) -> Optional[List[str]]:
+        """Parse URL path part to Python rep (str)."""
+        valid_archives = []
+        for archive in value.split(','):
+            if archive not in taxonomy.ARCHIVES:
+                continue
+            # Support old archives.
+            if archive in taxonomy.ARCHIVES_SUBSUMED:
+                cat = taxonomy.CATEGORIES[taxonomy.ARCHIVES_SUBSUMED[archive]]
+                archive = cat['in_archive']
+            valid_archives.append(archive)
+        if not valid_archives:
+            raise ValidationError()
+        return valid_archives
+
+    def to_url(self, value: List[str]) -> str:
+        """Cast Python rep (list) to URL path part."""
+        return ",".join(value)

--- a/search/domain/advanced.py
+++ b/search/domain/advanced.py
@@ -36,5 +36,7 @@ class AdvancedQuery(Query):
     """
 
     date_range: Optional[DateRange] = None
-    primary_classification: ClassificationList = field(default_factory=ClassificationList)
+    primary_classification: ClassificationList = field(
+        default_factory=ClassificationList
+    )
     terms: FieldedSearchList = field(default_factory=FieldedSearchList)

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -149,6 +149,9 @@ class SimpleQuery(Query):
 
     search_field: str = field(default_factory=str)
     value: str = field(default_factory=str)
+    primary_classification: ClassificationList = field(
+        default_factory=ClassificationList
+    )
 
 
 @dataclass(init=True)

--- a/search/factory.py
+++ b/search/factory.py
@@ -9,6 +9,7 @@ from arxiv.base import Base
 from arxiv.base.middleware import wrap, request_logs
 from search.routes import ui
 from search.services import index
+from search.converters import ArchiveConverter
 
 s3 = FlaskS3()
 
@@ -21,6 +22,7 @@ def create_ui_web_app() -> Flask:
 
     app = Flask('search')
     app.config.from_pyfile('config.py')
+    app.url_map.converters['archive'] = ArchiveConverter
 
     index.init_app(app)
 

--- a/search/routes/ui.py
+++ b/search/routes/ui.py
@@ -1,7 +1,7 @@
 """Provides the main search user interfaces."""
 
 import json
-from typing import Dict, Callable, Union, Any, Optional
+from typing import Dict, Callable, Union, Any, Optional, List
 from functools import wraps
 from urllib.parse import urljoin, urlparse, parse_qs, urlencode, urlunparse
 
@@ -68,17 +68,15 @@ def apply_response_headers(response: Response) -> Response:
     return response
 
 
+@blueprint.route('<archive:archives>', methods=['GET'])
 @blueprint.route('/', methods=['GET'])
-def search() -> Union[str, Response]:
-    """First pass at a search results page."""
-    response, code, headers = simple.search(request.args)
+def search(archives: Optional[List[str]] = None) -> Union[str, Response]:
+    """Simple search interface."""
+    response, code, headers = simple.search(request.args, archives)
     logger.debug(f"controller returned code: {code}")
     if code == status.HTTP_200_OK:
-        return render_template(
-            "search/search.html",
-            pagetitle="Search",
-            **response
-        )
+        return render_template("search/search.html", pagetitle="Search",
+                               archives=archives, **response)
     elif (code == status.HTTP_301_MOVED_PERMANENTLY
           or code == status.HTTP_303_SEE_OTHER):
         return redirect(headers['Location'], code=code)
@@ -163,6 +161,15 @@ def url_for_page_builder() -> Dict[str, Callable]:
         url: str = url_unparse(parts)
         return url
     return dict(url_for_page=url_for_page)
+
+
+@blueprint.context_processor
+def current_url_params_builder() -> Dict[str, Callable]:
+    """Add a function that gets the GET params from the current URL."""
+    def current_url_params() -> str:
+        """Get the GET params from the current URL."""
+        return url_encode(request.args)
+    return dict(current_url_params=current_url_params)
 
 
 @blueprint.context_processor

--- a/search/services/index/simple.py
+++ b/search/services/index/simple.py
@@ -4,7 +4,7 @@ from elasticsearch_dsl import Search
 
 from search.domain import SimpleQuery
 
-from .prepare import SEARCH_FIELDS
+from .prepare import SEARCH_FIELDS, limit_by_classification
 from .util import sort
 
 
@@ -28,6 +28,8 @@ def simple_search(search: Search, query: SimpleQuery) -> Search:
     """
     search = search.filter("term", is_current=True)
     q = SEARCH_FIELDS[query.search_field](query.value)
+    if query.primary_classification:
+        q &= limit_by_classification(query.primary_classification)
     search = search.query(q)
     search = sort(query, search)
     return search

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -11,7 +11,11 @@
 {% endblock title %}
 
 {% block within_content %}
-  <form method="GET" action="{{ url_for('ui.search') }}" {% if not query and not results %} class="breathe-vertical" {% endif %} aria-role="search">
+  <form method="GET" action="{{ url_for('ui.search', archives=archives) }}" {% if not query and not results %} class="breathe-vertical" {% endif %} aria-role="search">
+    {% if archives %}
+      Searching in archive{% if archives|length > 1 %}s{% endif %} <strong>{{ archives|join(", ") }}</strong>. <a href="{{ url_for('ui.search') }}?{{ current_url_params() }}">Search in all archives.</a>
+    {% endif %}
+    
     {% if has_classic_format %}
       {{ search_macros.show_classic_author_search() }}
     {% endif %}


### PR DESCRIPTION
This behaves much the same way that it does for advanced search, but the mechanics are a bit different.

There is a URL mapping rule that catches ``/<archive:archives>``, where the URL converter ``archive`` is ``search.converters.ArchiveConverter`` (see diff). This looks for active or subsumed archives, and injects a list of archive IDs into the simple search route.

The current archives are displayed above the search box, with a link that takes the user to an arXiv-wide search.

![image](https://user-images.githubusercontent.com/3451594/42654196-d2eb5852-85e5-11e8-86bd-0871df1545e2.png)
