### PR TITLE
ARXIVNG-983 Support searches for seven-digit arXiv ID partials

### DIFF
--- a/search/controllers/advanced/forms.py
+++ b/search/controllers/advanced/forms.py
@@ -12,7 +12,7 @@ from wtforms import widgets
 
 from arxiv import taxonomy
 
-from search.controllers.util import doesNotStartWithWildcard, stripWhiteSpace
+from search.controllers.util import does_not_start_with_wildcard, strip_white_space
 
 
 class MultiFormatDateField(DateField):
@@ -52,8 +52,8 @@ class FieldForm(Form):
 
     # pylint: disable=too-few-public-methods
 
-    term = StringField("Search term...", filters=[stripWhiteSpace],
-                       validators=[doesNotStartWithWildcard])
+    term = StringField("Search term...", filters=[strip_white_space],
+                       validators=[does_not_start_with_wildcard])
     operator = SelectField("Operator", choices=[
         ('AND', 'AND'), ('OR', 'OR'), ('NOT', 'NOT')
     ], default='AND')

--- a/search/controllers/simple/forms.py
+++ b/search/controllers/simple/forms.py
@@ -7,7 +7,7 @@ from wtforms import Form, BooleanField, StringField, SelectField, validators, \
     widgets
 from wtforms.fields import HiddenField
 
-from search.controllers.util import doesNotStartWithWildcard, stripWhiteSpace
+from search.controllers.util import does_not_start_with_wildcard, strip_white_space
 
 
 class SimpleSearchForm(Form):
@@ -31,8 +31,8 @@ class SimpleSearchForm(Form):
         ('full_text', 'Full text')
     ])
     query = StringField('Search or Article ID',
-                        filters=[stripWhiteSpace],
-                        validators=[doesNotStartWithWildcard])
+                        filters=[strip_white_space],
+                        validators=[does_not_start_with_wildcard])
     size = SelectField('results per page', default=50, choices=[
         ('25', '25'),
         ('50', '50'),

--- a/search/controllers/tests.py
+++ b/search/controllers/tests.py
@@ -1,11 +1,12 @@
 """Tests for :mod:`search.controllers`."""
 
 from unittest import TestCase, mock
+from datetime import date
 
 from arxiv import status
 from search.domain import DocumentSet, Document
 from search.controllers import health_check
-from .util import catch_underscore_syntax
+from .util import catch_underscore_syntax, is_old_papernum
 
 
 class TestHealthCheck(TestCase):
@@ -72,3 +73,16 @@ class TestUnderscoreHandling(TestCase):
             catch_underscore_syntax("")
         except Exception as e:
             self.fail(e)
+
+
+class TestOldPapernumDetection(TestCase):
+    """Test :func:`.is_old_papernum`."""
+
+    def test_is_old_papernum(self):
+        """User enters a 7-digit number that looks like an old papernum."""
+        self.assertFalse(is_old_papernum('9106001'))
+        self.assertTrue(is_old_papernum('9107001'))
+        self.assertFalse(is_old_papernum('9200001'))
+        self.assertTrue(is_old_papernum('9201001'))
+        self.assertTrue(is_old_papernum('0703999'))
+        self.assertFalse(is_old_papernum('0704001'))

--- a/search/controllers/tests.py
+++ b/search/controllers/tests.py
@@ -73,16 +73,3 @@ class TestUnderscoreHandling(TestCase):
             catch_underscore_syntax("")
         except Exception as e:
             self.fail(e)
-
-
-class TestOldPapernumDetection(TestCase):
-    """Test :func:`.is_old_papernum`."""
-
-    def test_is_old_papernum(self):
-        """User enters a 7-digit number that looks like an old papernum."""
-        self.assertFalse(is_old_papernum('9106001'))
-        self.assertTrue(is_old_papernum('9107001'))
-        self.assertFalse(is_old_papernum('9200001'))
-        self.assertTrue(is_old_papernum('9201001'))
-        self.assertTrue(is_old_papernum('0703999'))
-        self.assertFalse(is_old_papernum('0704001'))

--- a/search/controllers/tests.py
+++ b/search/controllers/tests.py
@@ -6,7 +6,7 @@ from datetime import date
 from arxiv import status
 from search.domain import DocumentSet, Document
 from search.controllers import health_check
-from .util import catch_underscore_syntax, is_old_papernum
+from .util import catch_underscore_syntax
 
 
 class TestHealthCheck(TestCase):

--- a/search/controllers/util.py
+++ b/search/controllers/util.py
@@ -7,12 +7,19 @@ from wtforms import Form, StringField, validators
 
 from search.domain import Query
 
-CLASSIC_AUTHOR = r"([A-Za-z]+)_([a-zA-Z])(?=$|\s)"
+CLASSIC_AUTHOR = r'([A-Za-z]+)_([a-zA-Z])(?=$|\s)'
+OLD_ID_NUMBER = \
+   r'(910[7-9]|911[0-2]|9[2-9](0[1-9]|1[0-2])|0[0-6](0[1-9]|1[0-2])|070[1-3])'\
+   r'(00[1-9]|0[1-9][0-9]|[1-9][0-9][0-9])'
+"""
+The number part of the old arXiv identifier looks like YYMMNNN.
 
-# TODO: these should all be snake-case, or all camel-case, but not both.
+The old arXiv identifier scheme was used between 1991-07 and 2007-03
+(inclusive).
+"""
 
 
-def doesNotStartWithWildcard(form: Form, field: StringField) -> None:
+def does_not_start_with_wildcard(form: Form, field: StringField) -> None:
     """Check that ``value`` does not start with a wildcard character."""
     if not field.data:
         return
@@ -20,7 +27,7 @@ def doesNotStartWithWildcard(form: Form, field: StringField) -> None:
         raise validators.ValidationError('Search cannot start with a wildcard')
 
 
-def stripWhiteSpace(value: str) -> str:
+def strip_white_space(value: str) -> str:
     """Strip whitespace from form input."""
     if not value:
         return value
@@ -39,6 +46,7 @@ def paginate(query: Query, data: dict) -> Query:
     Returns
     -------
     :class:`.Query`
+
     """
     query.page_start = int(data.get('start', 0))
     query.page_size = int(data.get('size', 50))
@@ -50,4 +58,11 @@ def catch_underscore_syntax(term: str) -> Tuple[str, bool]:
     match = re.search(CLASSIC_AUTHOR, term)
     if not match:
         return term, False
-    return re.sub(CLASSIC_AUTHOR, "\g<1>, \g<2>;", term).rstrip(';'), True
+    return re.sub(CLASSIC_AUTHOR, r'\g<1>, \g<2>;', term).rstrip(';'), True
+
+
+def is_old_papernum(term: str) -> bool:
+    """Check whether term matches 7-digit pattern for old arXiv ID numbers."""
+    if term and re.search(OLD_ID_NUMBER, term):
+        return True
+    return False

--- a/search/controllers/util.py
+++ b/search/controllers/util.py
@@ -8,15 +8,6 @@ from wtforms import Form, StringField, validators
 from search.domain import Query
 
 CLASSIC_AUTHOR = r'([A-Za-z]+)_([a-zA-Z])(?=$|\s)'
-OLD_ID_NUMBER = \
-   r'(910[7-9]|911[0-2]|9[2-9](0[1-9]|1[0-2])|0[0-6](0[1-9]|1[0-2])|070[1-3])'\
-   r'(00[1-9]|0[1-9][0-9]|[1-9][0-9][0-9])'
-"""
-The number part of the old arXiv identifier looks like YYMMNNN.
-
-The old arXiv identifier scheme was used between 1991-07 and 2007-03
-(inclusive).
-"""
 
 
 def does_not_start_with_wildcard(form: Form, field: StringField) -> None:
@@ -59,10 +50,3 @@ def catch_underscore_syntax(term: str) -> Tuple[str, bool]:
     if not match:
         return term, False
     return re.sub(CLASSIC_AUTHOR, r'\g<1>, \g<2>;', term).rstrip(';'), True
-
-
-def is_old_papernum(term: str) -> bool:
-    """Check whether term matches 7-digit pattern for old arXiv ID numbers."""
-    if term and re.search(OLD_ID_NUMBER, term):
-        return True
-    return False

--- a/search/services/index/authors.py
+++ b/search/services/index/authors.py
@@ -9,7 +9,7 @@ from elasticsearch_dsl import Search, Q, SF
 
 from arxiv.base import logging
 
-from .util import wildcardEscape, escape, STRING_LITERAL, \
+from .util import wildcard_escape, escape, STRING_LITERAL, \
     remove_single_characters, has_wildcard
 
 logger = logging.getLogger(__name__)

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -21,8 +21,8 @@ from arxiv.base import logging
 from search.domain import SimpleQuery, Query, AdvancedQuery, Classification, \
     ClassificationList
 from .util import strip_tex, Q_, is_tex_query, is_literal_query, escape, \
-    wildcard_escape, remove_single_characters, has_wildcard, is_old_papernum \
-    parse_date
+    wildcard_escape, remove_single_characters, has_wildcard, is_old_papernum, \
+    parse_date, parse_date_partial
 
 from .highlighting import HIGHLIGHT_TAG_OPEN, HIGHLIGHT_TAG_CLOSE
 from .authors import author_query, author_id_query, orcid_query

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -21,8 +21,7 @@ from arxiv.base import logging
 from search.domain import SimpleQuery, Query, AdvancedQuery, Classification, \
     ClassificationList
 from .util import strip_tex, Q_, is_tex_query, is_literal_query, escape, \
-    wildcard_escape, remove_single_characters, has_wildcard, \
-    match_date_partial, is_old_papernum
+    wildcard_escape, remove_single_characters, has_wildcard, is_old_papernum
 
 from .highlighting import HIGHLIGHT_TAG_OPEN, HIGHLIGHT_TAG_CLOSE
 from .authors import author_query, author_id_query, orcid_query

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -10,7 +10,6 @@ See :func:`._query_all_fields` for information on how results are scored.
 from typing import Any, List, Tuple, Callable, Dict, Optional
 from functools import reduce, wraps
 from operator import ior, iand
-import re
 from string import punctuation
 
 from elasticsearch_dsl import Search, Q, SF

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -21,7 +21,8 @@ from arxiv.base import logging
 from search.domain import SimpleQuery, Query, AdvancedQuery, Classification, \
     ClassificationList
 from .util import strip_tex, Q_, is_tex_query, is_literal_query, escape, \
-    wildcard_escape, remove_single_characters, has_wildcard, is_old_papernum
+    wildcard_escape, remove_single_characters, has_wildcard, is_old_papernum \
+    parse_date
 
 from .highlighting import HIGHLIGHT_TAG_OPEN, HIGHLIGHT_TAG_CLOSE
 from .authors import author_query, author_id_query, orcid_query

--- a/search/services/index/tests/test_util.py
+++ b/search/services/index/tests/test_util.py
@@ -40,3 +40,16 @@ class TestMatchDatePartial(TestCase):
         ym, rmd = util.match_date_partial(term)
         self.assertEqual(ym, '1995-05')
         self.assertEqual(rmd, 'old paper', 'Should have a remainder')
+
+
+class TestOldPapernumDetection(TestCase):
+    """Test :func:`.index.util.is_old_papernum`."""
+
+    def test_is_old_papernum(self):
+        """User enters a 7-digit number that looks like an old papernum."""
+        self.assertFalse(util.is_old_papernum('9106001'))
+        self.assertTrue(util.is_old_papernum('9107001'))
+        self.assertFalse(util.is_old_papernum('9200001'))
+        self.assertTrue(util.is_old_papernum('9201001'))
+        self.assertTrue(util.is_old_papernum('0703999'))
+        self.assertFalse(util.is_old_papernum('0704001'))

--- a/search/services/index/tests/tests.py
+++ b/search/services/index/tests/tests.py
@@ -8,7 +8,7 @@ from elasticsearch_dsl.query import Range, Match, Bool, Nested
 
 from search.services import index
 from search.services.index import advanced
-from search.services.index.util import wildcardEscape, Q_
+from search.services.index.util import wildcard_escape, Q_
 from search.domain import Query, FieldedSearchTerm, DateRange, Classification,\
     AdvancedQuery, FieldedSearchList, ClassificationList, SimpleQuery, \
     DocumentSet
@@ -125,7 +125,7 @@ class TestWildcardSearch(TestCase):
     def test_match_any_wildcard_is_present(self):
         """A * wildcard is present in the query."""
         qs = "Foo t*"
-        qs_escaped, wildcard = wildcardEscape(qs)
+        qs_escaped, wildcard = wildcard_escape(qs)
 
         self.assertTrue(wildcard, "Wildcard should be detected")
         self.assertEqual(qs, qs_escaped, "The querystring should be unchanged")
@@ -138,7 +138,7 @@ class TestWildcardSearch(TestCase):
     def test_match_any_wildcard_in_literal(self):
         """A * wildcard is present in a string literal."""
         qs = '"Foo t*"'
-        qs_escaped, wildcard = wildcardEscape(qs)
+        qs_escaped, wildcard = wildcard_escape(qs)
 
         self.assertEqual(qs_escaped, '"Foo t\*"', "Wildcard should be escaped")
         self.assertFalse(wildcard, "Wildcard should not be detected")
@@ -151,7 +151,7 @@ class TestWildcardSearch(TestCase):
     def test_multiple_match_any_wildcard_in_literal(self):
         """Multiple * wildcards are present in a string literal."""
         qs = '"Fo*o t*"'
-        qs_escaped, wildcard = wildcardEscape(qs)
+        qs_escaped, wildcard = wildcard_escape(qs)
 
         self.assertEqual(qs_escaped, '"Fo\*o t\*"',
                          "Both wildcards should be escaped")
@@ -165,7 +165,7 @@ class TestWildcardSearch(TestCase):
     def test_mixed_wildcards_in_literal(self):
         """Both * and ? characters are present in a string literal."""
         qs = '"Fo? t*"'
-        qs_escaped, wildcard = wildcardEscape(qs)
+        qs_escaped, wildcard = wildcard_escape(qs)
 
         self.assertEqual(qs_escaped, '"Fo\? t\*"',
                          "Both wildcards should be escaped")
@@ -179,7 +179,7 @@ class TestWildcardSearch(TestCase):
     def test_wildcards_both_inside_and_outside_literal(self):
         """Wildcard characters are present both inside and outside literal."""
         qs = '"Fo? t*" said the *'
-        qs_escaped, wildcard = wildcardEscape(qs)
+        qs_escaped, wildcard = wildcard_escape(qs)
 
         self.assertEqual(qs_escaped, '"Fo\? t\*" said the *',
                          "Wildcards in literal should be escaped")
@@ -193,7 +193,7 @@ class TestWildcardSearch(TestCase):
     def test_wildcards_inside_outside_multiple_literals(self):
         """Wildcard chars are everywhere, and there are multiple literals."""
         qs = '"Fo?" s* "yes*" o?'
-        qs_escaped, wildcard = wildcardEscape(qs)
+        qs_escaped, wildcard = wildcard_escape(qs)
 
         self.assertEqual(qs_escaped, '"Fo\?" s* "yes\*" o?',
                          "Wildcards in literal should be escaped")
@@ -208,7 +208,7 @@ class TestWildcardSearch(TestCase):
     def test_wildcard_at_opening_of_string(self):
         """A wildcard character is the first character in the querystring."""
         with self.assertRaises(index.QueryError):
-            wildcardEscape("*nope")
+            wildcard_escape("*nope")
 
         with self.assertRaises(index.QueryError):
             Q_('match', 'title', '*nope')


### PR DESCRIPTION
The arXiv ID partial ("papernum") detection is stricter than in the classic search but unlike classic search, if a papernum is detected the query is not limited to the paper ID field. In other words, if a user enters what looks like a papernum in the "all fields" search, that term will actually get queried across all fields.