### PR TITLE
ARXIVNG-982 Make "back" link on advanced search results more obvious

### DIFF
--- a/search/templates/search/advanced_search.html
+++ b/search/templates/search/advanced_search.html
@@ -324,23 +324,43 @@
 {% endblock title %}
 
 {% block within_content %}
-  <div class="is-clearfix" style="height: 2.5em"> {# TODO - adjust this layout so that it matches across all forms less awkwardly #}
-    <div class="is-pulled-right">
-      {% if query %}
-      <a href="{{ url_with_params("ui.search", {}, {"order": query.order, "size": query.page_size}) }}">Simple Search</a>
-      {% else %}
-      <a href="{{ url_with_params("ui.search", {}, {"order": form.order.data, "size": form.size.data }) }}">Simple Search</a>
-      {% endif %}
-    </div>
-  </div>
-
   {% if show_form %}
+    <div class="is-clearfix" style="height: 2.5em"> {# TODO - adjust this layout so that it matches across all forms less awkwardly #}
+      <div class="is-pulled-right">
+        {% if query %}
+        <a href="{{ url_with_params("ui.search", {}, {"order": query.order, "size": query.page_size}) }}">Simple Search</a>
+        {% else %}
+        <a href="{{ url_with_params("ui.search", {}, {"order": form.order.data, "size": form.size.data }) }}">Simple Search</a>
+        {% endif %}
+      </div>
+    </div>
     {{ advanced_query(form) }}
   {% else %}
     {% if has_classic_format %}
       {{ search_macros.show_classic_author_search() }}
     {% endif %}
-    <p class="subtitle is-5">Refine your query: <a href="{{ current_url_sans_parameters('advanced') }}">{{ query }}</a> or <a href="{{ url_for('ui.advanced_search') }}">Start a new search</a></p>
+    <div class="level">
+      <div class="level-left" style="max-width: 90%;"> <!-- width adjustment for long query strings -->
+        <div class="level-item">
+          <a class="button" href="{{ url_for('ui.advanced_search') }}">Start a new search</a>
+        </div>
+        <div class="level-item">
+          <a class="button is-link" href="{{ current_url_sans_parameters('advanced') }}">Refine This Query</a>
+        </div>
+        <div class="level-item" style="word-wrap:break-word; max-width: 70%;"><a href="{{ current_url_sans_parameters('advanced') }}">{{ query }}</a>
+        </div> <!-- styling here is also to fit long query strings without breaking layout -->
+      </div>
+      <div class="level-right">
+        <div class="level-item">
+          {% if query %}
+          <a href="{{ url_with_params("ui.search", {}, {"order": query.order, "size": query.page_size}) }}">Simple Search</a>
+          {% else %}
+          <a href="{{ url_with_params("ui.search", {}, {"order": form.order.data, "size": form.size.data }) }}">Simple Search</a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
     {% if results %}
         {{ search_macros.size_and_order(form, url_for('ui.advanced_search')) }}
         {{ search_macros.search_results(form, results, metadata, external_url, url_for_page, url_for_author_search, is_current, query.hide_abstracts) }}

--- a/search/templates/search/base.html
+++ b/search/templates/search/base.html
@@ -37,7 +37,7 @@
 {% endblock addl_head %}
 
 {% block content %}
-  <div class="level">
+  <div class="level is-marginless">
     <div class="level-left">
       <h1 class="title is-clearfix">{% block title %}Search{% endblock title %}</h1>
     </div>


### PR DESCRIPTION
I tightened up the layout a little to reduce unnecessary vertical white space. We had a display block for the "Simple Search" link that needed a bit of adjustment as a result.
Also, added some width limiters so that very long queries don't push the "Simple Search" link off the page.

<img width="1249" alt="screen shot 2018-07-13 at 4 20 23 pm" src="https://user-images.githubusercontent.com/17456668/42712889-5919cb5e-86bb-11e8-8a27-a42c5c9abf66.png">

<img width="1275" alt="screen shot 2018-07-13 at 4 06 03 pm" src="https://user-images.githubusercontent.com/17456668/42712941-955ed6d6-86bb-11e8-8606-7675758409f0.png">
