### PR TITLE
ARXIVNG-1008 incremented version number in feedback collector to 0.4

### DIFF
--- a/Dockerfile-agent
+++ b/Dockerfile-agent
@@ -4,7 +4,7 @@
 #  article metadata becomes available. Subscribes to a Kinesis stream for
 #  notifications about new metadata.
 
-FROM arxiv/search:0.3
+FROM arxiv/search:0.4
 
 WORKDIR /opt/arxiv
 

--- a/search/config.py
+++ b/search/config.py
@@ -224,8 +224,8 @@ FLASKS3_FORCE_MIMETYPE = os.environ.get('FLASKS3_FORCE_MIMETYPE', 1)
 FLASKS3_ACTIVE = os.environ.get('FLASKS3_ACTIVE', 0)
 
 # Settings for display of release information
-RELEASE_NOTES_URL = 'https://confluence.cornell.edu/x/mBtOFQ'
-RELEASE_NOTES_TEXT = 'Search v0.3 released 2018-05-14'
+RELEASE_NOTES_URL = 'https://confluence.cornell.edu/x/8H5OFQ'
+RELEASE_NOTES_TEXT = 'Search v0.4 released 2018-07-18'
 
 
 # TODO: one place to set the version, update release notes text, JIRA issue

--- a/search/templates/search/base.html
+++ b/search/templates/search/base.html
@@ -28,7 +28,7 @@
     	},
       fieldValues: {
         "components": ["16000"],  // Search component.
-        "versions": ["14133"],  // Release search-0.3
+        "versions": ["14134"],  // Release search-0.4
         "customfield_11401": window.location.href
       }
     };


### PR DESCRIPTION
Per ARXIVNG-1009 I also updated the link to the release notes, and updated the version number displayed with that link.