### PR TITLE
ARXIVNG-1089 fixed null condition in date partial search

### DIFF
--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -285,7 +285,7 @@ def _query_all_fields(term: str) -> Q:
             match_date = Q("bool", should=match_dates, minimum_should_match=1,
                            _name="announced_date_first")
             logger.debug('match date: %s', match_date)
-        queries.insert(0, match_date)
+            queries.insert(0, match_date)
 
         # Now join the announcement date query with the all-fields queries.
         if match_date is not None:


### PR DESCRIPTION
Stems from user report that:

```
The second bug occurs when using the "All fields" search option with the query "HMI SHARP ####" where #### is seemingly any four digit number.

For example, the following query will return error 500.
https://arxiv.org/search/?query=HMI+SHARP+4724&searchtype=all
```

This was a simple bug in which a ``None`` object was added to a list of what was expected to be ES DSL ``Q`` objects.