### PR TITLE
ARXIVNG-1206 ARXIVNG-1212 Include only a subset of fields in query response, filter by license

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-arxiv-base = "==0.11.1rc5"
+arxiv-base = "==0.11.1rc6"
 arxiv-auth = "==0.1.0rc14"
 boto = "==2.48.0"
 "boto3" = "==1.6.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f14dcfd9ec69893845bb7478b52f195e7afe2dffc3c667d277e87afc12ec5dd3"
+            "sha256": "d1b1281c8c786c7f3ca24513df4fea25993b9b4bb08fcf0c66586d6455701ac4"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -23,10 +23,10 @@
         },
         "arxiv-base": {
             "hashes": [
-                "sha256:e8f8504a4b8ca5a190a3572882cd1cfd544b071cc2deec1e62d90635787da66f"
+                "sha256:2c3eb57d1cab3af774b72b2ea0cd673d0e67d78f41dbbc11b6ee648c38bb92c9"
             ],
             "index": "pypi",
-            "version": "==0.11.1rc5"
+            "version": "==0.11.1rc6"
         },
         "bleach": {
             "hashes": [
@@ -453,9 +453,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:ef6569ad403520ee13e180e1bfd6ed71a0254192a934ec1dbd3dbf48f4aa9524"
+                "sha256:c5951d9ef1d5404ed04bae5a16b60a0779087378928f997a294d1229c6ca4d3e"
             ],
-            "version": "==1.2.11"
+            "version": "==1.2.12"
         },
         "thrift": {
             "hashes": [
@@ -670,10 +670,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0",
-                "sha256:f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b"
+                "sha256:0886227f54515e592aaa2e5a553332c73962917f2831f1b0f9b9f4380a4b9807",
+                "sha256:f95a1e147590f204328170981833854229bb2912ac3d5f89e2a8ccd2834800c9"
             ],
-            "version": "==17.1"
+            "version": "==18.0"
         },
         "pygments": {
             "hashes": [
@@ -729,11 +729,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:95acd6648902333647a0e0564abdb28a74b0a76d2333148aa35e5ed1f56d3c4b",
-                "sha256:c091dbdd5cc5aac6eb95d591a819fd18bccec90ffb048ec465b165a48b839b45"
+                "sha256:652eb8c566f18823a022bb4b6dbc868d366df332a11a0226b5bc3a798a479f17",
+                "sha256:d222626d8356de702431e813a05c68a35967e3d66c6cd1c2c89539bb179a7464"
             ],
             "index": "pypi",
-            "version": "==1.8.0"
+            "version": "==1.8.1"
         },
         "sphinx-autodoc-typehints": {
             "hashes": [

--- a/docs/source/search_api.rst
+++ b/docs/source/search_api.rst
@@ -30,7 +30,5 @@ The service endpoints are defined in :mod:`search.routes.api`:
 - The paper metadata endpoint :func:`search.routes.api.paper` provides more
   detailed metadata for a specific arXiv e-print.
 
-Requests are handled by the controllers in :mod:`search.controllers.api`. As of
-this writing, the :class:`search.domain.api.APIQuery` domain class is identical
-to :class:`search.domain.advanced.AdvancedQuery`, but this may change in future
-versions.
+Requests are handled by the controllers in :mod:`search.controllers.api`, using
+the :class:`search.domain.api.APIQuery` domain class.

--- a/schema/resources/Document.json
+++ b/schema/resources/Document.json
@@ -221,7 +221,7 @@
       "type": "string",
       "format": "uri",
       "description": "Canonical arXiv URI."
-    },
+    }
   },
   "required": [
     "paper_id",

--- a/schema/resources/Document.json
+++ b/schema/resources/Document.json
@@ -92,6 +92,10 @@
       "type": "string"
     },
     "paper_id": {
+      "description": "arXiv paper identifier without version affix.",
+      "type": "string"
+    },
+    "paper_id_v": {
       "description": "arXiv paper identifier with version affix.",
       "type": "string"
     },
@@ -114,6 +118,10 @@
           }
         }
       }
+    },
+    "href": {
+      "type": "string",
+      "format": "uri"
     },
     "fulltext": {
       "type": "string"
@@ -205,16 +213,9 @@
     }
   },
   "required": [
-    "abstract",
-    "authors",
-    "submitted_date",
-    "is_current",
-    "is_withdrawn",
-    "license",
     "paper_id",
-    "primary_classification",
-    "title",
-    "source",
-    "version"
+    "paper_id_v",
+    "version",
+    "href"
   ]
 }

--- a/schema/resources/Document.json
+++ b/schema/resources/Document.json
@@ -203,19 +203,31 @@
         },
         "href": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "Location of the detailed metadata record available via the API"
+        },
+        "canonical": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical arXiv URI."
         },
         "paper_id": {
           "description": "Paper ID with version affix of latest version.",
           "type": "string"
         }
       }
-    }
+    },
+    "canonical": {
+      "type": "string",
+      "format": "uri",
+      "description": "Canonical arXiv URI."
+    },
   },
   "required": [
     "paper_id",
     "paper_id_v",
     "version",
-    "href"
+    "href",
+    "canonical"
   ]
 }

--- a/schema/search.yaml
+++ b/schema/search.yaml
@@ -192,6 +192,42 @@ paths:
             type: array
             items:
               type: string
+        - name: start_date
+          in: query
+          description: |
+            Limit results to papers submitted or announced (see ``date_type``)
+            on or after this date.
+          required: false
+          style: form
+          schema:
+            type: string
+            format: date
+        - name: end_date
+          in: query
+          description: |
+            Limit results to papers submitted or announced (see ``date_type``)
+            on or before this date.
+          required: false
+          style: form
+          schema:
+            type: string
+            format: date
+        - name: date_type
+          in: query
+          description: |
+            The date property used to apply ``start_date`` and ``end_date``
+            filters. Note that ``announced_date_first`` has only year and month
+            precision.
+          required: false
+          style: form
+          schema:
+            type: string
+            default: submitted_date
+            enum:
+              - submitted_date_first
+              - submitted_date
+              - announced_date_first
+
       responses:
         '200':
           description: All arXiv papers that respond to specified query.

--- a/schema/search.yaml
+++ b/schema/search.yaml
@@ -41,6 +41,18 @@ paths:
             type: array
             items:
               type: string
+        - name: include
+          in: query
+          description: |
+            Fields to include in the result set, in addition to paper ID and
+            version.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         '200':
           description: All arXiv papers that respond to specified query.

--- a/schema/search.yaml
+++ b/schema/search.yaml
@@ -183,7 +183,8 @@ paths:
           in: query
           description: |
             Fields to include in the result set, in addition to paper ID and
-            version.
+            version. See ``DocumentMetadata.json`` specification for all
+            available fields.
           required: false
           style: form
           explode: true

--- a/schema/search.yaml
+++ b/schema/search.yaml
@@ -1,16 +1,18 @@
 openapi: "3.0.0"
 info:
-  version: "0.1"
+  version: "0.1.2"
   title: "arXiv Search API"
-  description: "A RESTful API for arXiv metadata."
-  termsOfService: "https://arxiv.org/help/general",
+  description: |
+    A query API for arXiv paper metadata.
+  termsOfService: "https://arxiv.org/help/general"
   contact:
     name: "arXiv API Team"
     email: nextgen@arxiv.org
   license:
     name: MIT
 servers:
-  - url: https://arxiv.org/api
+  - url: https://api.arxiv.org/metadata/
+    description: Metadata API endpoint.
 paths:
   /:
     get:
@@ -23,7 +25,142 @@ paths:
           in: query
           description: |
             Performs a query across all fields. Has the same behavior as the
-            simple search function on the main arXiv website.
+            simple search function on the main arXiv website. Supports quoted
+            literals, wildcards, etc.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: author
+          in: query
+          description: |
+            Search by author name. For the most precise name search, use
+            ``surname(s), forename(s)`` or ``surname(s), initial(s)``. Author
+            names enclosed in quotes will return only exact matches only.
+            Diacritic character variants are automatically searched. For
+            more information about the limitations of searching by author name,
+            see https://blogs.cornell.edu/arxiv/2018/05/04/release-search-v0-2-some-notes-on-names/.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: title
+          in: query
+          description: |
+            Text search in paper titles. Supports quoted literals and
+            wildcards.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: abstract
+          in: query
+          description: |
+            Text search in paper abstracts. Supports quoted literals and
+            wildcards.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: comments
+          in: query
+          description: |
+            Text search in paper comments. Supports quoted literals and
+            wildcards. See https://arxiv.org/help/prep#comments for a
+            description of this field.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: journal_ref
+          in: query
+          description: |
+            Text search in journal reference. Supports quoted literals and
+            wildcards. See https://arxiv.org/help/prep#journal for a
+            description of this field.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: report_num
+          in: query
+          description: |
+            Text search in report number. Supports quoted literals and
+            wildcards. See https://arxiv.org/help/prep#report for a description
+            of this field.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: acm_class
+          in: query
+          description: |
+            Keyword match on ACM classification code. Supports wildcards. See
+            https://arxiv.org/help/prep#acm for a description of this field.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: msc_class
+          in: query
+          description: |
+            Keyword match on MSC classification code. Supports wildcards. See
+            https://arxiv.org/help/prep#msc for a description of this field.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: doi
+          in: query
+          description: |
+            Keyword match on DOI. Supports wildcards. See
+            https://arxiv.org/help/prep#doi for a description of this field.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: paper_id
+          in: query
+          description: |
+            Keyword match on arXiv paper ID, with our without a version affix.
+            Supports wildcards. See https://arxiv.org/help/arxiv_identifier for
+            information about arXiv paper identifiers.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: orcid
+          in: query
+          description: |
+            Match on author ORCID ID. For information about ORCID IDs,
+            see https://arxiv.org/help/orcid. Note that ORCID IDs are only
+            available for the submitter and any author-owners who have claimed
+            the paper. See also
+            https://blogs.cornell.edu/arxiv/2018/05/04/release-search-v0-2-some-notes-on-names/.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: author_id
+          in: query
+          description: |
+            Match on arXiv author identifier. For more information about author
+            identifiers, see https://arxiv.org/help/author_identifiers. Note
+            that author identifiers are only available for the submitter and
+            any author-owners who have claimed the paper. See also
+            https://blogs.cornell.edu/arxiv/2018/05/04/release-search-v0-2-some-notes-on-names/.
           required: false
           style: form
           explode: true
@@ -33,7 +170,8 @@ paths:
           in: query
           description: |
             Slug for the primary category or categories to which results
-            should be limited.
+            should be limited. Valid categories are defined at
+            https://github.com/cul-it/arxiv-base/blob/master/arxiv/taxonomy/__init__.py#L306.
           required: false
           style: form
           explode: true
@@ -68,7 +206,10 @@ paths:
                 $ref: '#/components/schemas/Error'
   /{id}:
     get:
-      description: Return metadata about an arXiv paper by arXiv ID.
+      description: |
+        Get metadata about an arXiv paper by arXiv ID. See
+        https://arxiv.org/help/arxiv_identifier for information about arXiv
+        paper identifiers.
       operationId: getPaperByID
       parameters:
         - name: id

--- a/search/config.py
+++ b/search/config.py
@@ -233,6 +233,7 @@ BASE_SERVER = os.environ.get('BASE_SERVER', 'arxiv.org')
 
 URLS = [
     ("pdf", "/pdf/<arxiv:paper_id>v<string:version>", BASE_SERVER),
+    ("abs", "/abs/<arxiv:paper_id>v<string:version>", BASE_SERVER),
     ("pdfonly", "/pdf/<arxiv:paper_id>v<string:version>", BASE_SERVER),
     ("dvi", "/dvi/<arxiv:paper_id>v<string:version>", BASE_SERVER),
     ("html", "/html/<arxiv:paper_id>v<string:version>", BASE_SERVER),

--- a/search/controllers/api/__init__.py
+++ b/search/controllers/api/__init__.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 EASTERN = timezone('US/Eastern')
 
 
-def search(params: MultiDict) -> Tuple[DocumentSet, int, Dict[str, Any]]:
+def search(params: MultiDict) -> Tuple[Dict[str, Any], int, Dict[str, Any]]:
     """
     Handle a search request from the API.
 
@@ -66,7 +66,7 @@ def search(params: MultiDict) -> Tuple[DocumentSet, int, Dict[str, Any]]:
     return {'results': document_set, 'query': q}, status.HTTP_200_OK, {}
 
 
-def paper(paper_id: str) -> Tuple[Document, int, Dict[str, Any]]:
+def paper(paper_id: str) -> Tuple[Dict[str, Any], int, Dict[str, Any]]:
     """
     Handle a request for paper metadata from the API.
 

--- a/search/controllers/api/__init__.py
+++ b/search/controllers/api/__init__.py
@@ -124,7 +124,7 @@ def _get_fielded_terms(params: MultiDict) -> Optional[FieldedSearchList]:
 
 def _get_date_params(params: MultiDict) -> Optional[DateRange]:
     date_params = {}
-    for field in ['start_date', 'end_date', 'date_type']:
+    for field in ['start_date', 'end_date']:
         value = params.getlist(field)
         if not value:
             continue
@@ -136,6 +136,8 @@ def _get_date_params(params: MultiDict) -> Optional[DateRange]:
         except ValueError:
             raise BadRequest({'field': field, 'reason': 'invalid datetime'})
         date_params[field] = dt
+    if 'date_type' in params:
+        date_params['date_type'] = params.get('date_type')
     if date_params:
         return DateRange(**date_params)  # type: ignore
     return None

--- a/search/domain/api.py
+++ b/search/domain/api.py
@@ -14,7 +14,7 @@ def get_default_extra_fields() -> List[str]:
 
 def get_required_fields() -> List[str]:
     """These fields should always be included."""
-    return ['paper_id', 'paper_id_v', 'version', 'href']
+    return ['paper_id', 'paper_id_v', 'version', 'href', 'canonical']
 
 
 @dataclass

--- a/search/domain/api.py
+++ b/search/domain/api.py
@@ -1,10 +1,18 @@
 """API-specific domain classes."""
 
-from .base import DateRange, Query, ClassificationList
+from .base import DateRange, Query, ClassificationList, List
 from .advanced import FieldedSearchList, FieldedSearchTerm
 
 from dataclasses import dataclass, field
 from typing import NamedTuple, Optional
+
+
+def get_default_extra_fields() -> List[str]:
+    return ['title']
+
+
+def get_required_fields() -> List[str]:
+    return ['paper_id', 'paper_id_v', 'version']
 
 
 @dataclass
@@ -14,9 +22,16 @@ class APIQuery(Query):
 
     Similar to an advanced query.
     """
-
     date_range: Optional[DateRange] = None
     primary_classification: ClassificationList = field(
         default_factory=ClassificationList
     )
     terms: FieldedSearchList = field(default_factory=FieldedSearchList)
+
+    include_fields: List[str] = field(default_factory=get_default_extra_fields)
+
+    def __post_init__(self) -> None:
+        self.include_fields = list(
+            set(get_required_fields() + self.include_fields)
+        )
+        print(self.include_fields)

--- a/search/domain/api.py
+++ b/search/domain/api.py
@@ -8,11 +8,13 @@ from typing import NamedTuple, Optional
 
 
 def get_default_extra_fields() -> List[str]:
+    """These are the default extra fields."""
     return ['title']
 
 
 def get_required_fields() -> List[str]:
-    return ['paper_id', 'paper_id_v', 'version']
+    """These fields should always be included."""
+    return ['paper_id', 'paper_id_v', 'version', 'href']
 
 
 @dataclass
@@ -22,16 +24,16 @@ class APIQuery(Query):
 
     Similar to an advanced query.
     """
+
     date_range: Optional[DateRange] = None
     primary_classification: ClassificationList = field(
         default_factory=ClassificationList
     )
     terms: FieldedSearchList = field(default_factory=FieldedSearchList)
-
     include_fields: List[str] = field(default_factory=get_default_extra_fields)
 
     def __post_init__(self) -> None:
+        """Be sure that the required fields are prepended to include_fields."""
         self.include_fields = list(
             set(get_required_fields() + self.include_fields)
         )
-        print(self.include_fields)

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -165,6 +165,7 @@ class Query:
         ('paper_id', 'arXiv identifier'),
         ('doi', 'DOI'),
         ('orcid', 'ORCID'),
+        ('license', 'License (URI)'),
         ('author_id', 'arXiv author ID'),
         ('help', 'Help pages'),
         ('full_text', 'Full text')

--- a/search/routes/api/__init__.py
+++ b/search/routes/api/__init__.py
@@ -38,7 +38,7 @@ def search() -> Response:
     # requested = request.accept_mimetypes.best_match([JSON, ATOM_XML])
     # if requested == ATOM_XML:
     #     return serialize.as_atom(data), status, headers
-    return serialize.as_json(data), status_code, headers
+    return serialize.as_json(data['results'], query=data['query']), status_code, headers
 
 
 @blueprint.route('<arxiv:paper_id>v<string:version>', methods=['GET'])
@@ -46,4 +46,4 @@ def search() -> Response:
 def paper(paper_id: str, version: str) -> Response:
     """Document metadata endpoint."""
     data, status_code, headers = api.paper(f'{paper_id}v{version}')
-    return serialize.as_json(data), status_code, headers
+    return serialize.as_json(data['results']), status_code, headers

--- a/search/routes/api/__init__.py
+++ b/search/routes/api/__init__.py
@@ -38,7 +38,8 @@ def search() -> Response:
     # requested = request.accept_mimetypes.best_match([JSON, ATOM_XML])
     # if requested == ATOM_XML:
     #     return serialize.as_atom(data), status, headers
-    return serialize.as_json(data['results'], query=data['query']), status_code, headers
+    response_data = serialize.as_json(data['results'], query=data['query'])
+    return response_data, status_code, headers
 
 
 @blueprint.route('<arxiv:paper_id>v<string:version>', methods=['GET'])

--- a/search/routes/api/serialize.py
+++ b/search/routes/api/serialize.py
@@ -117,17 +117,18 @@ class JSONSerializer(BaseSerializer):
             )),
             ('title', doc.title),
             ('version', doc.version),
-            ('latest', cls._transform_latest(doc))
+            ('latest', cls._transform_latest(doc)),
+            ('href', url_for("api.paper", paper_id=doc.paper_id,
+                             version=doc.version, _external=True))
         ]
 
         # Only return fields that have been explicitly requested.
         if query is not None:
             _data = {field: value for field, value in fields
                      if field in query.include_fields}
-            _data['href'] = url_for("api.paper", paper_id=doc.paper_id,
-                                    version=doc.version, _external=True)
-            return _data
-        return {field: value for field, value in fields}
+        else:
+            _data = {field: value for field, value in fields}
+        return _data
 
     @classmethod
     def serialize(cls, document_set: DocumentSet,

--- a/search/routes/api/serialize.py
+++ b/search/routes/api/serialize.py
@@ -1,11 +1,12 @@
 """Serializers for API responses."""
 
-from typing import Union
+from typing import Union, Optional
 from lxml import etree
 from flask import jsonify, url_for
 
 from arxiv import status
-from search.domain import DocumentSet, Document, Classification, Person
+from search.domain import DocumentSet, Document, Classification, Person, \
+    APIQuery
 
 
 class BaseSerializer(object):
@@ -28,7 +29,9 @@ class JSONSerializer(BaseSerializer):
         }
 
     @classmethod
-    def _transform_classification(cls, clsn: Classification) -> dict:
+    def _transform_classification(cls, clsn: Classification) -> Optional[dict]:
+        if clsn.category is None:
+            return None
         return {
             'group': clsn.group,
             'archive': clsn.archive,
@@ -43,7 +46,9 @@ class JSONSerializer(BaseSerializer):
         }
 
     @classmethod
-    def _transform_latest(cls, document: Document) -> dict:
+    def _transform_latest(cls, document: Document) -> Optional[dict]:
+        if not document.latest:
+            return None
         return {
             "paper_id": document.latest,
             "href": url_for("api.paper", paper_id=document.paper_id,
@@ -60,63 +65,77 @@ class JSONSerializer(BaseSerializer):
         }
 
     @classmethod
-    def transform_document(cls, doc: Document) -> dict:
+    def transform_document(cls, doc: Document,
+                           query: Optional[APIQuery] = None) -> dict:
         """Select a subset of :class:`Document` properties for public API."""
-        return {
-            'abs_categories': doc.abs_categories,
-            'abstract': doc.abstract,
-            'acm_class': doc.acm_class,
-            'owners': [
+        fields = [
+            ('abs_categories', doc.abs_categories),
+            ('abstract', doc.abstract),
+            ('acm_class', doc.acm_class),
+            ('owners', [
                 cls._transform_person(owner) for owner in doc.owners
                 if owner is not None
-            ],
-            'authors': [
+            ]),
+            ('authors', [
                 cls._transform_person(author) for author in doc.authors
                 if author is not None
-            ],
-            'comments': doc.comments,
-            'submitted_date': doc.submitted_date,
-            'submitted_date_first': doc.submitted_date_first,
-            'announced_date_first': (
+            ]),
+            ('comments', doc.comments),
+            ('authors_freeform', doc.authors_freeform),
+            ('submitted_date', doc.submitted_date),
+            ('submitted_date_first', doc.submitted_date_first),
+            ('announced_date_first', (
                 doc.announced_date_first.strftime('%Y-%m')
                 if doc.announced_date_first is not None
                 else None
-            ),
-            'paper_id': doc.paper_id_v,
-            'doi': doc.doi,
-            'formats': [
+            )),
+            ('paper_id', doc.paper_id),
+            ('paper_id_v', doc.paper_id_v),
+            ('doi', doc.doi),
+            ('formats', [
                 cls._transform_format(fmt, doc.paper_id, doc.version)
                 for fmt in doc.formats
-            ],
-            'is_current': doc.is_current,
-            'is_withdrawn': doc.is_withdrawn,
-            'journal_ref': doc.journal_ref,
-            'license': cls._transform_license(doc.license),
-            'msc_class': doc.msc_class,
-            'primary_classification': cls._transform_classification(
-                doc.primary_classification
-            ),
-            'secondary_classification': [
+            ]),
+            ('is_current', doc.is_current),
+            ('is_withdrawn', doc.is_withdrawn),
+            ('journal_ref', doc.journal_ref),
+            ('license',
+             cls._transform_license(doc.license) if doc.license else None),
+            ('msc_class', doc.msc_class),
+            ('primary_classification',
+             cls._transform_classification(doc.primary_classification)
+             if doc.primary_classification else None),
+            ('secondary_classification', [
                 cls._transform_classification(clsn)
                 for clsn in doc.secondary_classification
-            ],
-            'report_num': doc.report_num,
-            'source': doc.source,  # TODO: link?
-            'submitter': (
+            ]),
+            ('report_num', doc.report_num),
+            ('source', doc.source),  # TODO, link?
+            ('submitter', (
                 cls._transform_person(doc.submitter)
                 if doc.submitter is not None else None
-            ),
-            'title': doc.title,
-            'version': doc.version,
-            'latest': cls._transform_latest(doc),
-        }
+            )),
+            ('title', doc.title),
+            ('version', doc.version),
+            ('latest', cls._transform_latest(doc))
+        ]
+
+        # Only return fields that have been explicitly requested.
+        if query is not None:
+            _data = {field: value for field, value in fields
+                     if field in query.include_fields}
+            _data['href'] = url_for("api.paper", paper_id=doc.paper_id,
+                                    version=doc.version, _external=True)
+            return _data
+        return {field: value for field, value in fields}
 
     @classmethod
-    def serialize(cls, document_set: DocumentSet) -> str:
+    def serialize(cls, document_set: DocumentSet,
+                  query: Optional[APIQuery] = None) -> str:
         """Generate JSON for a :class:`DocumentSet`."""
         serialized: str = jsonify({
             'results': [
-                cls.transform_document(doc)
+                cls.transform_document(doc, query=query)
                 for doc in document_set.results
             ],
             'metadata': {
@@ -129,17 +148,21 @@ class JSONSerializer(BaseSerializer):
         return serialized
 
     @classmethod
-    def serialize_document(cls, document: Document) -> str:
+    def serialize_document(cls, document: Document,
+                           query: Optional[APIQuery] = None) -> str:
         """Generate JSON for a single :class:`Document`."""
-        serialized: str = jsonify(cls.transform_document(document))
+        serialized: str = jsonify(
+            cls.transform_document(document, query=query)
+        )
         return serialized
 
 
-def as_json(document_or_set: Union[DocumentSet, Document]) -> str:
+def as_json(document_or_set: Union[DocumentSet, Document],
+            query: Optional[APIQuery] = None) -> str:
     """Serialize a :class:`DocumentSet` as JSON."""
     if type(document_or_set) is DocumentSet:
-        return JSONSerializer.serialize(document_or_set)  # type: ignore
-    return JSONSerializer.serialize_document(document_or_set)  # type: ignore
+        return JSONSerializer.serialize(document_or_set, query=query)  # type: ignore
+    return JSONSerializer.serialize_document(document_or_set, query=query)  # type: ignore
 
 
 # TODO: implement me!

--- a/search/routes/api/serialize.py
+++ b/search/routes/api/serialize.py
@@ -54,6 +54,8 @@ class JSONSerializer(BaseSerializer):
             "href": url_for("api.paper", paper_id=document.paper_id,
                             version=document.latest_version,
                             _external=True),
+            "canonical": url_for("abs", paper_id=document.paper_id,
+                                 version=document.latest_version),
             "version": document.latest_version
         }
 
@@ -119,7 +121,9 @@ class JSONSerializer(BaseSerializer):
             ('version', doc.version),
             ('latest', cls._transform_latest(doc)),
             ('href', url_for("api.paper", paper_id=doc.paper_id,
-                             version=doc.version, _external=True))
+                             version=doc.version, _external=True)),
+            ('canonical', url_for("abs", paper_id=doc.paper_id,
+                                  version=doc.version))
         ]
 
         # Only return fields that have been explicitly requested.

--- a/search/routes/api/tests/test_api.py
+++ b/search/routes/api/tests/test_api.py
@@ -44,7 +44,7 @@ class TestAPISearchRequests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @mock.patch(f'{factory.__name__}.api.api')
-    def test_with_valid_token(self, mock_api_controller):
+    def test_with_valid_token(self, mock_controller):
         """Client auth token has required public read scope."""
         document = domain.Document(
             submitted_date=datetime.now(),
@@ -100,7 +100,8 @@ class TestAPISearchRequests(TestCase):
             results=[document],
             metadata={'start': 0, 'end': 1, 'size': 50, 'total': 1}
         )
-        mock_api_controller.search.return_value = docs, status.HTTP_200_OK, {}
+        r_data = {'results': docs, 'query': domain.APIQuery()}
+        mock_controller.search.return_value = r_data, status.HTTP_200_OK, {}
         token = helpers.generate_token('1234', 'foo@bar.com', 'foouser',
                                        scope=[auth.scopes.READ_PUBLIC])
         response = self.client.get('/', headers={'Authorization': token})
@@ -113,3 +114,86 @@ class TestAPISearchRequests(TestCase):
         )
         self.assertIsNone(jsonschema.validate(data, self.schema, resolver=res),
                           'Response content is valid per schema')
+
+        for field in domain.api.get_required_fields():
+            self.assertIn(field, data['results'][0])
+
+    @mock.patch(f'{factory.__name__}.api.api')
+    def test_with_valid_token_limit_fields(self, mock_controller):
+        """Client auth token has required public read scope."""
+        document = domain.Document(
+            submitted_date=datetime.now(),
+            submitted_date_first=datetime.now(),
+            announced_date_first=datetime.now(),
+            id='1234.5678',
+            abstract='very abstract',
+            authors=[
+                domain.Person(full_name='F. Bar', orcid='1234-5678-9012-3456')
+            ],
+            submitter=domain.Person(full_name='S. Ubmitter', author_id='su_1'),
+            modified_date=datetime.now(),
+            updated_date=datetime.now(),
+            is_current=True,
+            is_withdrawn=False,
+            license={
+                'uri': 'http://foo.license/1',
+                'label': 'Notalicense 5.4'
+            },
+            paper_id='1234.5678',
+            paper_id_v='1234.5678v6',
+            title='tiiiitle',
+            source={
+                'flags': 'A',
+                'format': 'pdftotex',
+                'size_bytes': 2
+            },
+            version=6,
+            latest='1234.5678v6',
+            latest_version=6,
+            report_num='somenum1',
+            msc_class=['c1'],
+            acm_class=['z2'],
+            journal_ref='somejournal (1991): 2-34',
+            doi='10.123456/7890',
+            comments='very science',
+            abs_categories='astro-ph.CO foo.BR',
+            formats=['pdf', 'other'],
+            primary_classification=domain.Classification(
+                group={'id': 'foo', 'name': 'Foo Group'},
+                archive={'id': 'foo', 'name': 'Foo Archive'},
+                category={'id': 'foo.BR', 'name': 'Foo Category'},
+            ),
+            secondary_classification=[
+                domain.Classification(
+                    group={'id': 'foo', 'name': 'Foo Group'},
+                    archive={'id': 'foo', 'name': 'Foo Archive'},
+                    category={'id': 'foo.BZ', 'name': 'Baz Category'},
+                )
+            ]
+        )
+        docs = domain.DocumentSet(
+            results=[document],
+            metadata={'start': 0, 'end': 1, 'size': 50, 'total': 1}
+        )
+
+        query = domain.APIQuery(include_fields=['abstract', 'license'])
+        r_data = {'results': docs, 'query': query}
+        mock_controller.search.return_value = r_data, status.HTTP_200_OK, {}
+        token = helpers.generate_token('1234', 'foo@bar.com', 'foouser',
+                                       scope=[auth.scopes.READ_PUBLIC])
+        response = self.client.get('/', headers={'Authorization': token})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = json.loads(response.data)
+        res = jsonschema.RefResolver(
+            'file://%s/' % os.path.abspath(os.path.dirname(self.SCHEMA_PATH)),
+            None
+        )
+        self.assertIsNone(jsonschema.validate(data, self.schema, resolver=res),
+                          'Response content is valid per schema')
+
+        for field in domain.api.get_required_fields():
+            self.assertEqual(
+                set(data['results'][0].keys()),
+                set(query.include_fields)
+            )

--- a/search/services/index/__init__.py
+++ b/search/services/index/__init__.py
@@ -407,6 +407,11 @@ class SearchSession(object):
             # fields and configuration for highlighting.
             current_search = highlighting.highlight(current_search)
 
+        if hasattr(query, 'include_fields'):
+            current_search = current_search.extra(
+                _source={'include': query.include_fields}
+            )
+
         with handle_es_exceptions():
             # Slicing the search adds pagination parameters to the request.
             resp = current_search[query.page_start:query.page_end].execute()

--- a/search/services/index/__init__.py
+++ b/search/services/index/__init__.py
@@ -407,7 +407,7 @@ class SearchSession(object):
             # fields and configuration for highlighting.
             current_search = highlighting.highlight(current_search)
 
-        if hasattr(query, 'include_fields'):
+        if isinstance(query, APIQuery):
             current_search = current_search.extra(
                 _source={'include': query.include_fields}
             )

--- a/search/services/index/prepare.py
+++ b/search/services/index/prepare.py
@@ -142,6 +142,11 @@ def _query_paper_id(term: str, operator: str = 'and') -> Q:
     return q
 
 
+def _license_query(term: str, operator: str = 'and') -> Q:
+    """Search by license, using its URI (exact)."""
+    return Q('term', **{'license__uri': term})
+
+
 def _query_combined(term: str) -> Q:
     # Only wildcards in literals should be escaped.
     wildcard_escaped, has_wildcard = wildcard_escape(term)
@@ -331,20 +336,31 @@ def limit_by_classification(classifications: ClassificationList) -> Q:
         _qs = []
         if classification.group:
             _qs.append(
-                Q("match", **{"primary_classification__group__id": {"query": classification.group}})
+                Q("match", **{
+                    "primary_classification__group__id": {
+                        "query": classification.group
+                    }
+                })
             )
         if classification.archive:
             _qs.append(
-                Q("match", **{"primary_classification__archive__id": {"query": classification.archive}})
+                Q("match", **{
+                    "primary_classification__archive__id": {
+                        "query": classification.archive
+                    }
+                })
             )
         if classification.category:
             _qs.append(
-                Q("match", **{"primary_classification__category__id": {"query": classification.category}})
+                Q("match", **{
+                    "primary_classification__category__id": {
+                        "query": classification.category
+                    }
+                })
             )
         return reduce(iand, _qs)
 
     return reduce(ior, [_to_q(clsn) for clsn in classifications])
-
 
 
 SEARCH_FIELDS: Dict[str, Callable[[str], Q]] = dict([
@@ -360,5 +376,6 @@ SEARCH_FIELDS: Dict[str, Callable[[str], Q]] = dict([
     ('paper_id', _query_paper_id),
     ('orcid', orcid_query),
     ('author_id', author_id_query),
+    ('license', _license_query),
     ('all', _query_all_fields)
 ])

--- a/search/services/index/results.py
+++ b/search/services/index/results.py
@@ -43,7 +43,6 @@ def to_document(raw: Union[Hit, dict], highlight: bool = True) -> Document:
     result['match'] = {}  # Hit on field, but no highlighting.
     result['truncated'] = {}    # Preview is truncated.
 
-    logger.debug('Raw data is a %s instance', type(raw))
     for key in Document.fields():
         if type(raw) is Hit:
             if not hasattr(raw, key):


### PR DESCRIPTION
Response content (both from ES to the app, and app to the client) can get really big, because our source documents are huge and our metadata documents are huge. 

This adds support for limiting fields to only a subset of those in the source document. In the index service, we look for ``.include_fields`` on the domain query object, and use those to do [source filtering](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html). We can use this in the future to improve performance for the search UI.

In the ``search.routes.api`` module, we look also look at the query object to decide what to send back to the client. The ``.serializer`` submodule only grabs fields from the result document if they are explicitly listed. The client should use the ``include`` parameter (exploding) to enumerate fields that are desired about the default set. E.g. ``?all=tensorflow&include=title&include=abstract`` returns:

```json
{
  "metadata": {
    "end": 50, 
    "size": 50, 
    "start": 0, 
    "total": 205
  }, 
  "results": [
    {
      "abstract": "Recursive neural networks have widely been used by researchers to handle applications with recursively or hierarchically structured data. However, embedded control flow deep learning frameworks such as TensorFlow, Theano, Caffe2, and MXNet fail to efficiently represent and execute such neural networks, due to lack of support for recursion. In this paper, we add recursion to the programming model of existing frameworks by complementing their design with recursive execution of dataflow graphs as well as additional APIs for recursive definitions. Unlike iterative implementations, which can only understand the topological index of each node in recursive data structures, our recursive implementation is able to exploit the recursive relationships between nodes for efficient execution based on parallel computation. We present an implementation on TensorFlow and evaluation results with various recursive neural network models, showing that our recursive implementation not only conveys the recursive nature of recursive neural networks better than other implementations, but also uses given resources more effectively to reduce training and inference time.", 
      "href": "http://127.0.0.1:5000/1809.00832v1", 
      "paper_id": "1809.00832", 
      "paper_id_v": "1809.00832v1", 
      "title": "Improving the Expressiveness of Deep Learning Frameworks with Recursion", 
      "version": 1
    }, 
    {
      "abstract": "In this paper we describe the anatomy of a real-time facial analysis system. The system recognizes the age, gender and facial expression from users in appearing in front of the camera. All components are based on convolutional neural networks, whose accuracy we study on commonly used training and evaluation sets. A key contribution of the work is the description of the interplay between processing threads for frame grabbing, face detection and the three types of recognition. The python code for executing the system uses common libraries--keras/tensorflow, opencv and dlib--and is available for download.", 
      "href": "http://127.0.0.1:5000/1809.05474v1", 
      "paper_id": "1809.05474", 
      "paper_id_v": "1809.05474v1", 
      "title": "Real Time System for Facial Analysis", 
      "version": 1
    }, 

```

Note that there are a few required fields that are always returned.

While I was at it (@rossmounce might find this interesting), I added support for the ``license`` parameter in API queries. This expects an exact match on license URI. For example, ``?all=tensorflow&include=title&include=license&license=http://creativecommons.org/publicdomain/zero/1.0/`` returns:

```json
{
  "metadata": {
    "end": 3, 
    "size": 50, 
    "start": 0, 
    "total": 3
  }, 
  "results": [
    {
      "href": "http://127.0.0.1:5000/1807.06535v2", 
      "license": {
        "href": "http://creativecommons.org/publicdomain/zero/1.0/", 
        "label": "Creative Commons Public Domain Declaration (CC0 1.0)"
      }, 
      "paper_id": "1807.06535", 
      "paper_id_v": "1807.06535v2", 
      "title": "A framework for remote sensing images processing using deep learning technique", 
      "version": 2
    }, 
    {
      "href": "http://127.0.0.1:5000/1806.08342v1", 
      "license": {
        "href": "http://creativecommons.org/publicdomain/zero/1.0/", 
        "label": "Creative Commons Public Domain Declaration (CC0 1.0)"
      }, 
      "paper_id": "1806.08342", 
      "paper_id_v": "1806.08342v1", 
      "title": "Quantizing deep convolutional networks for efficient inference: A whitepaper", 
      "version": 1
    }, 
    {
      "href": "http://127.0.0.1:5000/1803.03759v1", 
      "license": {
        "href": "http://creativecommons.org/publicdomain/zero/1.0/", 
        "label": "Creative Commons Public Domain Declaration (CC0 1.0)"
      }, 
      "paper_id": "1803.03759", 
      "paper_id_v": "1803.03759v1", 
      "title": "Speech Recognition: Keyword Spotting Through Image Recognition", 
      "version": 1
    }
  ]
}
```