### PR TITLE
ARXIVNG-1363 upgraded requests version; ARXIVNG-1362 added custom user agent

### DIFF
--- a/=2.20.0
+++ b/=2.20.0
@@ -1,0 +1,11 @@
+Installing requests…
+Requirement already satisfied: requests in /Users/brp53/.local/share/virtualenvs/arxiv-search-sJgjMA70/lib/python3.6/site-packages
+Requirement already satisfied: idna<2.8,>=2.5 in /Users/brp53/.local/share/virtualenvs/arxiv-search-sJgjMA70/lib/python3.6/site-packages (from requests)
+Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /Users/brp53/.local/share/virtualenvs/arxiv-search-sJgjMA70/lib/python3.6/site-packages (from requests)
+Requirement already satisfied: urllib3<1.25,>=1.21.1 in /Users/brp53/.local/share/virtualenvs/arxiv-search-sJgjMA70/lib/python3.6/site-packages (from requests)
+Requirement already satisfied: certifi>=2017.4.17 in /Users/brp53/.local/share/virtualenvs/arxiv-search-sJgjMA70/lib/python3.6/site-packages (from requests)
+
+Adding requests to Pipfile's [packages]…
+Installing dependencies from Pipfile.lock (d9f678)…
+To activate this project's virtualenv, run the following:
+ $ pipenv shell

--- a/search/services/metadata.py
+++ b/search/services/metadata.py
@@ -114,7 +114,8 @@ class DocMetaSession(object):
                 f'{document_id}: retrieve metadata from {target} with SSL'
                 f' verify {self._verify_cert}'
             )
-            response = requests.get(target, verify=self._verify_cert)
+            response = requests.get(target, verify=self._verify_cert,
+                                    headers={'User-Agent': 'arXiv/system'})
         except requests.exceptions.SSLError as e:
             logger.error('SSLError: %s', e)
             raise SecurityException('SSL failed: %s' % e) from e


### PR DESCRIPTION
We were using an insecure version of the ``requests`` package. Also, I added a custom ``User-Agent`` header. We could get even more robust with that, but not a strong requirement yet. 